### PR TITLE
fix(blog): clarify and refresh published articles

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -41,6 +41,15 @@ jobs:
       - name: Collect three measurements per route
         run: npx --yes @lhci/cli@0.15.1 collect --config=website/lighthouserc.json
 
+      - name: Preserve traces from the same measurements
+        if: always()
+        run: |
+          mkdir -p .lighthouseci
+          shopt -s nullglob
+          assets=(*.trace.json *.devtoolslog.json)
+          test "${#assets[@]}" -gt 0
+          mv -- "${assets[@]}" .lighthouseci/
+
       - name: Verify complete measurements
         run: node scripts/check-lighthouse-reports.mjs
 

--- a/scripts/public-release-audit.mjs
+++ b/scripts/public-release-audit.mjs
@@ -75,17 +75,24 @@ export async function auditIdentity(commit, verifyMerge) {
   if (author === allowedIdentity && committer === allowedIdentity) return [];
   // Names alone are forgeable. Only GitHub's verified, matching merge object
   // may use the repository owner's account alias and the web-flow committer.
-  if (author === githubAuthor && committer === githubCommitter && parents.length === 2 && verifyMerge) {
+  if (author === githubAuthor && committer === githubCommitter &&
+      (parents.length === 1 || parents.length === 2) && verifyMerge) {
     try {
       const remote = await verifyMerge(sha);
       const verification = remote.commit?.verification;
+      // A signed one-parent web commit is not necessarily a squash merge.
+      // Bind that exception to the merged PR that introduced this exact SHA.
+      const isMergedSquash = Array.isArray(remote.pullRequests) && remote.pullRequests.some(pull =>
+        pull?.state === 'closed' && typeof pull.merged_at === 'string' && Number.isFinite(Date.parse(pull.merged_at)) &&
+        pull.merge_commit_sha === sha && pull.base?.ref === 'main' && pull.base?.repo?.full_name === repository);
       if (remote.sha === sha && remote.author?.login === 'originlabs-app' &&
           remote.committer?.login === 'web-flow' &&
           identity(remote.commit?.author) === author && identity(remote.commit?.committer) === committer &&
           JSON.stringify(remote.parents?.map(parent => parent.sha)) === JSON.stringify(parents) &&
           verification?.verified === true && verification.reason === 'valid' &&
           typeof verification.signature === 'string' && verification.signature.trim() &&
-          typeof verification.payload === 'string' && verification.payload.trim()) return [];
+          typeof verification.payload === 'string' && verification.payload.trim() &&
+          (parents.length === 2 || isMergedSquash)) return [];
     } catch {
       return [`${sha}: GitHub merge verification unavailable`];
     }
@@ -127,10 +134,9 @@ export function auditFiles(files, read = file => readFileSync(file)) {
   return failures;
 }
 
-async function verifyGitHubMerge(sha) {
-  if (!/^[a-f0-9]{40}$/.test(sha)) throw new Error('Invalid commit');
+async function readGitHub(path) {
   if (process.env.GH_TOKEN || process.env.GITHUB_TOKEN) {
-    const response = await fetch(`https://api.github.com/repos/${repository}/commits/${sha}`, {
+    const response = await fetch(`https://api.github.com/repos/${repository}/${path}`, {
       headers: {
         Accept: 'application/vnd.github+json',
         Authorization: `Bearer ${process.env.GH_TOKEN || process.env.GITHUB_TOKEN}`,
@@ -142,9 +148,18 @@ async function verifyGitHubMerge(sha) {
     if (!response.ok) throw new Error('GitHub verification failed');
     return response.json();
   }
-  return JSON.parse(execFileSync('gh', ['api', '--hostname', 'github.com', `repos/${repository}/commits/${sha}`], {
+  return JSON.parse(execFileSync('gh', ['api', '--hostname', 'github.com', `repos/${repository}/${path}`], {
     encoding: 'utf8', timeout: 20000, stdio: ['ignore', 'pipe', 'pipe'],
   }));
+}
+
+async function verifyGitHubMerge(sha) {
+  if (!/^[a-f0-9]{40}$/.test(sha)) throw new Error('Invalid commit');
+  const remote = await readGitHub(`commits/${sha}`);
+  if (remote.parents?.length === 1) {
+    remote.pullRequests = await readGitHub(`commits/${sha}/pulls?per_page=100`);
+  }
+  return remote;
 }
 
 async function main() {

--- a/scripts/public-release-audit.mjs
+++ b/scripts/public-release-audit.mjs
@@ -134,7 +134,7 @@ export function auditFiles(files, read = file => readFileSync(file)) {
   return failures;
 }
 
-async function readGitHub(path) {
+async function readGitHub(path, projection) {
   if (process.env.GH_TOKEN || process.env.GITHUB_TOKEN) {
     const response = await fetch(`https://api.github.com/repos/${repository}/${path}`, {
       headers: {
@@ -148,16 +148,17 @@ async function readGitHub(path) {
     if (!response.ok) throw new Error('GitHub verification failed');
     return response.json();
   }
-  return JSON.parse(execFileSync('gh', ['api', '--hostname', 'github.com', `repos/${repository}/${path}`], {
+  // Commit diffs can exceed the CLI buffer; retain every proof field, not patches.
+  return JSON.parse(execFileSync('gh', ['api', '--hostname', 'github.com', `repos/${repository}/${path}`, '--jq', projection], {
     encoding: 'utf8', timeout: 20000, stdio: ['ignore', 'pipe', 'pipe'],
   }));
 }
 
 async function verifyGitHubMerge(sha) {
   if (!/^[a-f0-9]{40}$/.test(sha)) throw new Error('Invalid commit');
-  const remote = await readGitHub(`commits/${sha}`);
+  const remote = await readGitHub(`commits/${sha}`, '{sha,author,committer,parents,commit}');
   if (remote.parents?.length === 1) {
-    remote.pullRequests = await readGitHub(`commits/${sha}/pulls?per_page=100`);
+    remote.pullRequests = await readGitHub(`commits/${sha}/pulls?per_page=100`, 'map({state,merged_at,merge_commit_sha,base})');
   }
   return remote;
 }

--- a/scripts/public-release-audit.test.mjs
+++ b/scripts/public-release-audit.test.mjs
@@ -173,7 +173,7 @@ test('CLI rejects staged secrets, private files and foreign identities in PR and
 
 test('CLI accepts a signed squash only when the associated pull request API confirms the merge', () => {
   const script = fileURLToPath(new URL('./public-release-audit.mjs', import.meta.url));
-  for (const scenario of ['merged', 'unmerged', 'unavailable']) {
+  for (const scenario of ['merged', 'large-commit', 'unmerged', 'unavailable']) {
     const cwd = mkdtempSync(join(tmpdir(), 'public-audit-squash-'));
     try {
       const env = { ...process.env, GH_TOKEN: '', GITHUB_TOKEN: '',
@@ -196,13 +196,18 @@ test('CLI accepts a signed squash only when the associated pull request API conf
         scenario, commit: { ...verifiedMerge, sha: head, parents: [{ sha: parent }] },
         pullRequests: [{ ...mergedPullRequest, merge_commit_sha: head, merged_at: scenario === 'unmerged' ? null : mergedPullRequest.merged_at }],
       };
+      if (scenario === 'large-commit') fixture.commit.files = [{ patch: 'x'.repeat(2 * 1024 * 1024) }];
       const fixturePath = join(cwd, 'api-fixture.json');
       writeFileSync(fixturePath, JSON.stringify(fixture));
       writeFileSync(join(cwd, 'gh'), `#!${process.execPath}
 const fixture = JSON.parse(require('node:fs').readFileSync(process.env.PUBLIC_AUDIT_FIXTURE, 'utf8'));
 const commitPath = 'repos/originlabs-app/galileo-protocol/commits/' + fixture.commit.sha;
-const endpoint = process.argv.at(-1);
-if (endpoint === commitPath) process.stdout.write(JSON.stringify(fixture.commit));
+const endpoint = process.argv.find(arg => arg.startsWith('repos/'));
+if (endpoint === commitPath) {
+  const projection = process.argv.indexOf('--jq');
+  const fields = projection === -1 ? Object.keys(fixture.commit) : process.argv[projection + 1].replace(/[{} ]/g, '').split(',');
+  process.stdout.write(JSON.stringify(Object.fromEntries(fields.map(key => [key, fixture.commit[key]]))));
+}
 else if (endpoint === commitPath + '/pulls?per_page=100' && fixture.scenario !== 'unavailable') process.stdout.write(JSON.stringify(fixture.pullRequests));
 else process.exit(1);
 `, { mode: 0o755 });
@@ -210,7 +215,7 @@ else process.exit(1);
         ...env, PATH: `${cwd}:${process.env.PATH}`, PUBLIC_AUDIT_FIXTURE: fixturePath,
         GITHUB_ACTIONS: 'true', GITHUB_EVENT_NAME: 'push', GITHUB_SHA: head,
       } });
-      assert.equal(result.status, scenario === 'merged' ? 0 : 1, `${scenario}: ${result.stderr}`);
+      assert.equal(result.status, ['merged', 'large-commit'].includes(scenario) ? 0 : 1, `${scenario}: ${result.stderr}`);
     } finally { rmSync(cwd, { recursive: true, force: true }); }
   }
 });

--- a/scripts/public-release-audit.test.mjs
+++ b/scripts/public-release-audit.test.mjs
@@ -20,6 +20,14 @@ const verifiedMerge = {
     verification: { verified: true, reason: 'valid', signature: 'signed payload', payload: 'commit payload' },
   },
 };
+const squash = { ...merge, parents: [parents[0]] };
+const mergedPullRequest = {
+  state: 'closed', merged_at: '2026-01-01T12:00:00Z', merge_commit_sha: sha,
+  base: { ref: 'main', repo: { full_name: 'originlabs-app/galileo-protocol' } },
+};
+const verifiedSquash = {
+  ...verifiedMerge, parents: [{ sha: parents[0] }], pullRequests: [mergedPullRequest],
+};
 
 test('ordinary contributions require both approved identities', async () => {
   assert.deepEqual(await auditIdentity({ sha, parents: [], author: owner, committer: owner }), []);
@@ -50,6 +58,53 @@ test('a GitHub merge requires matching signed API evidence', async () => {
   assert.ok((await auditIdentity(merge, async () => { throw new Error('unavailable'); })).length > 0);
   assert.ok((await auditIdentity({ ...merge, parents: [parents[0]] }, async () => verifiedMerge)).length > 0);
   assert.ok((await auditIdentity({ ...merge, author: 'some-bot <bot@example.org>' }, async () => verifiedMerge)).length > 0);
+});
+
+test('a signed GitHub squash requires its exact merged pull request into this repository main branch', async () => {
+  assert.deepEqual(await auditIdentity(squash, async () => verifiedSquash), []);
+  for (const alter of [
+    x => { delete x.pullRequests; },
+    x => { x.pullRequests = []; },
+    x => { x.pullRequests = {}; },
+    x => { x.pullRequests[0].state = 'open'; },
+    x => { x.pullRequests[0].merged_at = null; },
+    x => { x.pullRequests[0].merged_at = ''; },
+    x => { x.pullRequests[0].merged_at = 'invalid'; },
+    x => { x.pullRequests[0].merge_commit_sha = parents[0]; },
+    x => { x.pullRequests[0].base.ref = 'other-branch'; },
+    x => { x.pullRequests[0].base.repo.full_name = 'other/repository'; },
+  ]) {
+    const evidence = structuredClone(verifiedSquash);
+    alter(evidence);
+    assert.ok((await auditIdentity(squash, async () => evidence)).length > 0);
+  }
+});
+
+test('a squash cannot bypass commit identity, SHA, parents or signature verification', async () => {
+  for (const alter of [
+    x => { x.sha = 'd'.repeat(40); },
+    x => { x.parents = []; },
+    x => { x.parents[0].sha = parents[1]; },
+    x => { x.parents.push({ sha: parents[1] }); },
+    x => { x.author.login = 'other'; },
+    x => { x.committer.login = 'other'; },
+    x => { x.commit.author.email = 'other@example.org'; },
+    x => { x.commit.committer.name = 'Other'; },
+    x => { x.commit.verification.verified = false; },
+    x => { x.commit.verification.reason = 'unsigned'; },
+    x => { x.commit.verification.signature = ''; },
+    x => { x.commit.verification.payload = ''; },
+  ]) {
+    const evidence = structuredClone(verifiedSquash);
+    alter(evidence);
+    assert.ok((await auditIdentity(squash, async () => evidence)).length > 0);
+  }
+  for (const invalidParents of [[], [...parents, 'd'.repeat(40)]]) {
+    const evidence = { ...verifiedSquash, parents: invalidParents.map(sha => ({ sha })) };
+    assert.ok((await auditIdentity({ ...squash, parents: invalidParents }, async () => evidence)).length > 0);
+  }
+  assert.ok((await auditIdentity(squash, async () => { throw new Error('unavailable'); })).length > 0);
+  assert.ok((await auditIdentity(squash)).length > 0);
 });
 
 test('private paths and secrets cannot enter the release tree', () => {
@@ -113,5 +168,49 @@ test('CLI rejects staged secrets, private files and foreign identities in PR and
         assert.equal(result.status, scenario === 'clean' ? 0 : 1, `${eventName}/${scenario}: ${result.stderr}`);
       } finally { rmSync(cwd, { recursive: true, force: true }); }
     }
+  }
+});
+
+test('CLI accepts a signed squash only when the associated pull request API confirms the merge', () => {
+  const script = fileURLToPath(new URL('./public-release-audit.mjs', import.meta.url));
+  for (const scenario of ['merged', 'unmerged', 'unavailable']) {
+    const cwd = mkdtempSync(join(tmpdir(), 'public-audit-squash-'));
+    try {
+      const env = { ...process.env, GH_TOKEN: '', GITHUB_TOKEN: '',
+        GIT_AUTHOR_NAME: 'Pierre Beunardeau', GIT_COMMITTER_NAME: 'Pierre Beunardeau',
+        GIT_AUTHOR_EMAIL: 'pierre.beunardeau@originlabs.app', GIT_COMMITTER_EMAIL: 'pierre.beunardeau@originlabs.app' };
+      const git = args => execFileSync('git', args, { cwd, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+      git(['init', '--quiet']);
+      writeFileSync(join(cwd, 'README.md'), 'Contributor documentation');
+      git(['add', 'README.md']);
+      git(['-c', 'commit.gpgsign=false', 'commit', '--quiet', '-m', 'Initial contribution']);
+      const parent = git(['rev-parse', 'HEAD']).trim();
+      env.GIT_AUTHOR_NAME = 'originlabs-app';
+      env.GIT_COMMITTER_NAME = 'GitHub';
+      env.GIT_COMMITTER_EMAIL = 'noreply@github.com';
+      writeFileSync(join(cwd, 'README.md'), 'Updated contributor documentation');
+      git(['add', 'README.md']);
+      git(['-c', 'commit.gpgsign=false', 'commit', '--quiet', '-m', 'Squashed contribution']);
+      const head = git(['rev-parse', 'HEAD']).trim();
+      const fixture = {
+        scenario, commit: { ...verifiedMerge, sha: head, parents: [{ sha: parent }] },
+        pullRequests: [{ ...mergedPullRequest, merge_commit_sha: head, merged_at: scenario === 'unmerged' ? null : mergedPullRequest.merged_at }],
+      };
+      const fixturePath = join(cwd, 'api-fixture.json');
+      writeFileSync(fixturePath, JSON.stringify(fixture));
+      writeFileSync(join(cwd, 'gh'), `#!${process.execPath}
+const fixture = JSON.parse(require('node:fs').readFileSync(process.env.PUBLIC_AUDIT_FIXTURE, 'utf8'));
+const commitPath = 'repos/originlabs-app/galileo-protocol/commits/' + fixture.commit.sha;
+const endpoint = process.argv.at(-1);
+if (endpoint === commitPath) process.stdout.write(JSON.stringify(fixture.commit));
+else if (endpoint === commitPath + '/pulls?per_page=100' && fixture.scenario !== 'unavailable') process.stdout.write(JSON.stringify(fixture.pullRequests));
+else process.exit(1);
+`, { mode: 0o755 });
+      const result = spawnSync(process.execPath, [script], { cwd, encoding: 'utf8', env: {
+        ...env, PATH: `${cwd}:${process.env.PATH}`, PUBLIC_AUDIT_FIXTURE: fixturePath,
+        GITHUB_ACTIONS: 'true', GITHUB_EVENT_NAME: 'push', GITHUB_SHA: head,
+      } });
+      assert.equal(result.status, scenario === 'merged' ? 0 : 1, `${scenario}: ${result.stderr}`);
+    } finally { rmSync(cwd, { recursive: true, force: true }); }
   }
 });

--- a/website/content/blog/2026-02-01-v1-release.mdx
+++ b/website/content/blog/2026-02-01-v1-release.mdx
@@ -1,231 +1,59 @@
 ---
-title: "Galileo Protocol v1.0.0: Open Luxury Authenticity Standard"
-date: "2026-02-01"
-author: "Galileo Core Team"
-excerpt: "Today we release Galileo Protocol v1.0.0 - a comprehensive open-source framework for luxury goods authentication and traceability, built on blockchain technology and designed for regulatory compliance."
-description: "Galileo Protocol v1.0.0 is live: an open-source framework for luxury goods authentication and traceability, built on blockchain for regulatory compliance."
+title: 'Galileo v1.0: An Open Framework for Product Records'
+date: '2026-02-01'
+author: Galileo Core Team
+excerpt: >-
+  Galileo v1.0 provides specifications and reference code for product records.
+  Understand the release, its scope and what adoption still requires.
+description: >-
+  Galileo v1.0 provides specifications and reference code for product records.
+  Understand the release, its scope and what adoption still requires.
 tags:
   - release
   - announcement
   - v1.0
   - milestone
 published: true
+modified: '2026-09-12'
+faq:
+  - question: Does adopting Galileo make a product legally compliant?
+    answer: >-
+      No. A technical framework does not determine which laws apply to a product
+      or prove that an implementation meets them. Identify the applicable
+      requirements and verify the deployed system against those requirements.
 ---
+Galileo v1.0 provides open specifications and reference code for recording information about physical products. It gives implementers a starting point for product identity and traceability; it does not certify the authenticity of every object or the legal compliance of a deployment.
 
-## A New Era for Luxury Authenticity
+**Updated 12 September 2026:** the formal [v1.0.0 release](https://github.com/originlabs-app/galileo-protocol/releases/tag/v1.0.0) was published on 5 May 2026. This page retains its original February publication date and distinguishes that earlier announcement from the dated release.
 
-Today marks a significant milestone for the luxury industry. After months of rigorous specification, implementation, and community collaboration, we are proud to announce **Galileo Protocol v1.0.0** - an open-source standard for luxury goods authentication and provenance tracking.
+## What an implementer can use
 
-Galileo Protocol establishes a common, interoperable language for protecting brand heritage and human craftsmanship in an increasingly digital world.
+A product record brings together claims such as who made an item, which identifier refers to it and what happened during its life. Shared specifications help different systems exchange those claims without inventing a new format for each partner.
 
----
+The [v1.0 release notes](https://github.com/originlabs-app/galileo-protocol/blob/v1.0.0/release/v1.0.0/RELEASE-NOTES.md) describe the released package. Start there when selecting a version, then follow the [protocol documentation](/docs) for its interfaces and examples. A reference implementation shows one way to apply a specification; a business still needs to configure, secure and operate its own service.
 
-## The Problem We Solve
+For example, consider a fictional repair shop receiving a watch with a manufacturer record. A shared identifier can help the shop attach its service record to the right product. The shop must still examine the watch and describe the work accurately. A digital signature can help identify the record's issuer and detect changes to signed data, but it cannot establish that the physical watch has never been substituted.
 
-### The Counterfeiting Crisis
+## Where the regulatory boundary lies
 
-The global counterfeiting market exceeds **$500 billion annually**, with luxury goods among the most targeted sectors. Traditional authentication methods - holograms, certificates, serial numbers - are easily replicated or forged. Consumers lack reliable tools to verify authenticity, and brands struggle to protect their heritage.
+A Digital Product Passport, or DPP, makes specified product information accessible through a data carrier such as a QR code. The EU framework develops through requirements for particular product groups. The [European Commission's guidance for economic operators](https://single-market-economy.ec.europa.eu/single-market/digital-product-passport/economic-operators_en) does not set a universal 2027 deadline for every luxury product.
 
-### Regulatory Pressure
+Choose the relevant product category before treating a format or feature as a compliance requirement. Data protection also depends on the information collected, access permissions, retention and actual operation. An open protocol cannot settle those choices on its own.
 
-The European Union's **ESPR (Ecodesign for Sustainable Products Regulation)** mandates Digital Product Passports (DPPs) for regulated goods by 2027. Brands face a choice: build proprietary solutions that create data silos, or adopt open standards that enable interoperability.
+## What to establish before adoption
 
-### Data Fragmentation
+Begin with one record that another organisation needs to read. Agree who can issue and correct it, how the recipient checks its status and what happens if the service becomes unavailable. Then test that exchange with the chosen implementation.
 
-Each brand's authentication system is an island. Resale platforms cannot verify items. Customs agencies lack standardized verification protocols. Consumers accumulate incompatible certificates that become worthless the moment they leave the original ecosystem.
+The governance documents describe a proposed structure as well as participation arrangements. They should not be read as proof that every planned committee seat is occupied. Likewise, dates in an earlier roadmap describe intentions at the time; use a dated release to establish what became available.
 
-**Galileo Protocol solves all three problems with one unified standard.**
+These distinctions make the framework easier to evaluate: the released material is inspectable, while a proposed integration or future capability remains something to demonstrate.
 
----
+## Explore the release
 
-## What's Included in v1.0.0
+## Frequently asked questions
 
-Version 1.0.0 delivers **65 specifications** (26 markdown documents + 22 JSON/JSON-LD schemas + 17 Solidity contracts) across 8 technical domains, providing complete coverage for luxury goods authentication.
+### Does adopting Galileo make a product legally compliant?
 
-### Architecture
+No. A technical framework does not determine which laws apply to a product or prove that an implementation meets them. Identify the applicable requirements and verify the deployed system against those requirements.
 
-The foundational [hybrid on/off-chain architecture](/docs/architecture) balances transparency with privacy. On-chain components provide immutable authenticity records, while off-chain storage handles sensitive data with GDPR-compliant access controls.
-
-- **CRAB Model**: Create, Read, Archive, Burn operations for complete lifecycle management
-- **ML-DSA-65/87**: Post-quantum cryptographic signatures protecting against future threats
-
-### Identity Framework
-
-Our [identity system](/specifications/identity) implements the ERC-3643 v4.1.3 standard with 12 claim topics covering:
-
-- Brand identity verification
-- Artisan and craftsperson credentials
-- Manufacturing facility certification
-- Supply chain participant validation
-- Consumer privacy-preserving authentication
-
-### Token Standard
-
-The [ownership transfer specification](/specifications/token/ownership-transfer) enforces a strict 1:1 relationship between physical items and digital certificates:
-
-- 5 compliance modules for regulatory requirements
-- 8-step validation pipeline ensuring data integrity
-- Burn-on-transfer support for ownership transitions
-
-### Resolver System
-
-The [GS1 Digital Link 1.6.0 resolver](/specifications/resolver/digital-link-uri) enables universal lookups:
-
-- 14-digit GTIN compatibility
-- 4 stakeholder role types with granular permissions
-- QR code and NFC integration patterns
-
-### Data Schemas
-
-[EPCIS 2.0-aligned schemas](/specifications/schemas/alignment/cbv-mapping) for:
-
-- Digital Product Passport (DPP) records
-- Provenance events with 5 quality grades
-- Material composition and sustainability metrics
-
-### Compliance
-
-Built-in support for [regulatory frameworks](/docs/compliance):
-
-- **GDPR**: Full compliance via CRAB access model
-- **MiCA**: Crypto-asset regulatory readiness (July 2026)
-- **ESPR**: Digital Product Passport requirements (2027)
-
-### Infrastructure
-
-Enterprise-grade [operational specifications](/specifications/infrastructure):
-
-- 5 RBAC roles for access control
-- 7-year audit trail retention
-- Multi-region deployment patterns
-
-### Cryptography
-
-[Post-quantum security](/specifications/crypto/crypto-agility) future-proofing:
-
-- ML-DSA-65 for standard operations
-- ML-DSA-87 for high-security contexts
-- Hybrid classical/PQC transition paths
-
----
-
-## Use Cases
-
-### For Luxury Brands
-
-Deploy Galileo Protocol to issue verifiable digital certificates for every product. Track items through the supply chain, enable authorized resale verification, and provide customers with evidence-backed authenticity records.
-
-```json
-{
-  "@context": "https://galileo.example/v1",
-  "@type": "LuxuryItem",
-  "gtin": "01234567890123",
-  "brand": "Maison Example",
-  "category": "Haute Horlogerie",
-  "authenticity": {
-    "verified": true,
-    "verifier": "did:galileo:brand:maison-example",
-    "timestamp": "2026-02-01T00:00:00Z"
-  }
-}
-```
-
-### For Resale Platforms
-
-Integrate the resolver API to verify items listed on your marketplace. Provide buyers with confidence and reduce fraud-related chargebacks. Support the circular economy with trusted provenance data.
-
-### For Regulators
-
-Access standardized Digital Product Passport data through documented APIs. Verify compliance with ESPR requirements without requiring proprietary integrations with each brand.
-
-### For Consumers
-
-Scan any Galileo-enabled product to view its complete history: where it was made, who made it, every ownership transfer. Take control of your luxury investments with portable, verifiable certificates.
-
----
-
-## What's NOT in v1.0.0
-
-Transparency about scope is as important as feature announcements. Version 1.0.0 does **not** include:
-
-- **Mobile SDKs**: Native iOS/Android libraries are planned for v1.1
-- **Reference UI Components**: React/Vue component libraries coming in v1.2
-- **Multi-chain Deployments**: v1.0.0 targets EVM-compatible chains; cross-chain bridges planned for v1.3
-- **AI-powered Verification**: Computer vision authenticity checking is in research phase
-- **Marketplace Integration Templates**: Shopify/WooCommerce plugins planned for future releases
-
-These features are on our roadmap and will be delivered in subsequent minor versions.
-
----
-
-## Getting Started
-
-### For Developers
-
-1. **Read the Quick Start Guide**: [/docs/quick-start](/docs/quick-start)
-2. **Explore the Architecture**: [/docs/architecture](/docs/architecture)
-3. **Browse Specifications**: [/specifications](/specifications)
-4. **Join the Community**: GitHub discussions and contribution guidelines
-
-### For Brands
-
-1. **Review Compliance Requirements**: [/docs/compliance](/docs/compliance)
-2. **Assess Integration Scope**: Contact our partnership team
-3. **Plan Your Pilot**: We offer guided implementations for early adopters
-
-### For Researchers
-
-All specifications are published under **Apache 2.0** license. Academic use is encouraged and citations are appreciated. Contact us for research collaboration opportunities.
-
----
-
-## Roadmap
-
-### v1.1 (Q2 2026)
-- Mobile SDK for iOS and Android
-- Enhanced analytics dashboard
-- Additional language localizations
-
-### v1.2 (Q3 2026)
-- React and Vue component libraries
-- Shopify integration template
-- Extended EPCIS event types
-
-### v1.3 (Q4 2026)
-- Cross-chain bridge protocols
-- Advanced privacy features (ZK proofs)
-- AI verification research preview
-
----
-
-## Governance
-
-Galileo Protocol is developed under transparent, community-driven governance:
-
-- **License**: Apache 2.0
-- **Contributor Agreement**: DCO 1.1 (Developer Certificate of Origin)
-- **Technical Steering Committee**: 11 members with anti-dominance provisions (max 2 seats per organization)
-- **Decision Process**: Proposal-based with community review periods
-
-We believe open standards are only valuable if they remain truly open.
-
----
-
-## Thank You
-
-This release would not be possible without the contributions of many individuals and organizations:
-
-- The cryptography researchers who reviewed our post-quantum implementations
-- The luxury brands who provided real-world requirements and pilot feedback
-- The regulatory experts who ensured compliance framework accuracy
-- The open-source community who reviewed specifications and submitted improvements
-
-Galileo Protocol is built by the community, for the community.
-
-**The future of luxury authenticity is open. It starts today.**
-
----
-
-*Ready to dive in? Start with the [Quick Start Guide](/docs/quick-start) or explore the complete [Technical Documentation](/docs).*
-
-*Have questions? Open an issue on GitHub or join our community discussions.*
+Read the [v1.0.0 release](https://github.com/originlabs-app/galileo-protocol/releases/tag/v1.0.0) and the [documentation](/docs), then identify the smallest product-record exchange your team needs to prove.

--- a/website/content/blog/2026-02-01-v1-release.mdx
+++ b/website/content/blog/2026-02-01-v1-release.mdx
@@ -48,8 +48,6 @@ The governance documents describe a proposed structure as well as participation 
 
 These distinctions make the framework easier to evaluate: the released material is inspectable, while a proposed integration or future capability remains something to demonstrate.
 
-## Explore the release
-
 ## Frequently asked questions
 
 ### Does adopting Galileo make a product legally compliant?

--- a/website/content/blog/2026-03-22-production-deployment.mdx
+++ b/website/content/blog/2026-03-22-production-deployment.mdx
@@ -1,78 +1,53 @@
 ---
-title: "Production Deployment: Dashboard, Scanner & Infrastructure"
-date: "2026-03-22"
-author: "Galileo Core Team"
-excerpt: "The Galileo dashboard and scanner are now live on Vercel. This update covers the production deployment fixes, Cloudflare R2 storage, and the new automated changelog pipeline."
-description: "The Galileo dashboard and scanner are now live on Vercel, with production deployment fixes, Cloudflare R2 storage and a new automated changelog pipeline."
+title: 'Galileo Dashboard and Scanner: The March Deployment'
+date: '2026-03-22'
+author: Galileo Core Team
+excerpt: >-
+  The March 2026 deployment made Galileo's dashboard and scanner accessible.
+  What each application is for, and what a public demo does not establish.
+description: >-
+  The March 2026 deployment made Galileo's dashboard and scanner accessible.
+  What each application is for, and what a public demo does not establish.
 tags:
   - release
   - deployment
   - infrastructure
   - patch
 published: true
+modified: '2026-09-12'
+faq:
+  - question: Does an accessible scanner prove a complete production workflow?
+    answer: >-
+      No. A page can load without demonstrating every API operation, permission
+      check or connection to a physical product. Establish the network,
+      supported actions and remaining limits before relying on a demonstration.
 ---
+The March 2026 deployment made Galileo's dashboard and scanner accessible as separate applications. The dashboard is the administration entry point; the scanner is the public interface for looking up a product record.
 
-## What's New
+This is a historical deployment note. The [project changelog](https://github.com/originlabs-app/galileo-protocol/blob/main/CHANGELOG.md) records the March work; the public pages were checked again on 12 September 2026.
 
-Today we shipped several production deployment fixes and infrastructure updates that bring the full Galileo stack online.
+## What a visitor can open
 
----
+The [Galileo dashboard](https://galileo-dashboard.vercel.app) provides the administration interface. Opening its page does not demonstrate that a visitor has permission to create or change a product record.
 
-## Apps Now Live
+The [Galileo scanner](https://galileo-scanner.vercel.app) provides a product lookup interface. It identifies its network as **Base Sepolia**, a blockchain test network. An entry on that network is a demonstration record, not evidence of a commercial transaction on the main network.
 
-Both the B2B dashboard and the consumer scanner PWA are now deployed and publicly accessible:
+For a useful evaluation, follow one known test product from its record to the scanner. Check what the displayed information actually claims, who issued it and which operations require authorisation. Do not infer the state of the whole service from a successful page load.
 
-- **Dashboard** — [galileo-dashboard.vercel.app](https://galileo-dashboard.vercel.app) — brand admin portal for product lifecycle management
-- **Scanner PWA** — [galileo-scanner.vercel.app](https://galileo-scanner.vercel.app) — consumer QR verification app
+## What changed in the deployment
 
-The API on Railway was already live. This completes the full deployment of all three apps.
+The release addressed application startup and access to the files required by the API. It also moved product-image storage away from files tied to an individual application container.
 
----
+Cloudflare R2 is the storage service described in that update. Using separate object storage can preserve uploaded files across application restarts, but it is not a promise of permanent retention. Availability, deletion, backup and access arrangements still need to be defined by the operator.
 
-## Fixes
+Technical implementation details belong in the changelog and documentation. For the person evaluating Galileo, the useful question is whether the required action works with the right permissions and produces a record another participant can interpret.
 
-### Prisma 7 ESM Import Compatibility
+## Continue with a verifiable example
 
-Prisma 7 generates ESM files that require explicit `.js` extensions on all imports. The production build pipeline now patches these automatically via a `postbuild` script in the API Dockerfile, ensuring clean startup without `ERR_MODULE_NOT_FOUND` errors.
+## Frequently asked questions
 
-### Dockerfile Path Fix
+### Does an accessible scanner prove a complete production workflow?
 
-The `contracts/deployments` directory is now correctly copied to `/app` in the multi-stage Docker build. Previously, a misconfigured path prevented contract ABI resolution at runtime.
+No. A page can load without demonstrating every API operation, permission check or connection to a physical product. Establish the network, supported actions and remaining limits before relying on a demonstration.
 
-### Database Migrations
-
-Prisma migrations have been applied to the Railway production database. The `Product`, `ProductPassport`, `ProductEvent`, and all related tables are now in sync with the schema.
-
----
-
-## Infrastructure
-
-### Cloudflare R2 Storage
-
-Product image uploads are now persisted to Cloudflare R2. Previously the API ran in `local` mode, meaning uploads were lost on container restart. R2 provides permanent, geo-distributed storage without egress fees.
-
-### Basescan API Key
-
-Contract verification on Base Sepolia is now enabled, allowing ABIs and source code to be verified publicly on Basescan for transparency.
-
----
-
-## Automated Changelog Pipeline
-
-This release introduces the automated versioning and changelog system:
-
-- **`@changesets/cli`** — tracks changes per commit in `.changeset/` files
-- **`@changesets/changelog-github`** — formats changelogs with GitHub PR references
-- **GitHub Actions `release.yml`** — on push to `main`, automatically creates/updates a "Version Packages" PR; when merged, publishes the GitHub Release and generates a blog post
-
-Future releases will be tracked automatically through this pipeline.
-
----
-
-## Git Maintenance
-
-Orphaned local worktrees have been removed, reducing repository overhead.
-
----
-
-*Questions or issues? Open a GitHub issue or check the [documentation](/docs).*
+The later [Base Sepolia mint milestone](/blog/2026-05-04-live-base-sepolia-mint) links to a particular test-network transaction and explains its limited scope. Use that evidence alongside the [documentation](/docs) when deciding which part of the product journey to evaluate next.

--- a/website/content/blog/2026-03-22-production-deployment.mdx
+++ b/website/content/blog/2026-03-22-production-deployment.mdx
@@ -42,8 +42,6 @@ Cloudflare R2 is the storage service described in that update. Using separate ob
 
 Technical implementation details belong in the changelog and documentation. For the person evaluating Galileo, the useful question is whether the required action works with the right permissions and produces a record another participant can interpret.
 
-## Continue with a verifiable example
-
 ## Frequently asked questions
 
 ### Does an accessible scanner prove a complete production workflow?

--- a/website/content/blog/2026-05-04-live-base-sepolia-mint.mdx
+++ b/website/content/blog/2026-05-04-live-base-sepolia-mint.mdx
@@ -1,58 +1,53 @@
 ---
-title: "Live Base Sepolia Mint Verified"
-date: "2026-05-04"
-author: "Galileo Core Team"
-excerpt: "Galileo has verified a live constructor-path mint on Base Sepolia and aligned the public roadmap around the remaining identity role administration before full API-driven minting."
-description: "Galileo verified a live constructor-path mint on Base Sepolia and aligned its public roadmap around identity role administration before API-driven minting."
+title: 'Galileo''s Base Sepolia Mint: What the Record Proves'
+date: '2026-05-04'
+author: Galileo Core Team
+excerpt: >-
+  A successful Base Sepolia transaction records Galileo's test-network mint. See
+  what the receipt proves and what remains outside that evidence.
+description: >-
+  A successful Base Sepolia transaction records Galileo's test-network mint. See
+  what the receipt proves and what remains outside that evidence.
 tags:
   - release
   - blockchain
   - base
   - open-source
 published: true
+modified: '2026-09-12'
+faq:
+  - question: Was this a production sale of a physical product?
+    answer: >-
+      No. The cited transaction is on Base Sepolia, a test network. It records
+      contract creation and token issuance, not a sale, physical authentication
+      or a complete customer journey.
 ---
+Galileo verified a token issuance on **Base Sepolia, a blockchain test network**. The public transaction records the creation of a contract and an issuance during that creation; it does not establish a complete API-driven product journey.
 
-## Live Mint Evidence
+## The transaction to inspect
 
-Galileo has now verified a real Base Sepolia mint against the deployed ERC-3643 contract set. This confirms that the deployed token can mint on-chain and that the public deployment manifest is aligned with the current testnet state.
+The [Base Sepolia transaction](https://sepolia.basescan.org/tx/0x9cca203f8c3d988ac79bd5ea5c17cfd23a76d0d1393f32e0fb0f82875ccbc026) identifies the operation reported in this May milestone. Its receipt has a successful status and a Transfer event from the zero address, the event used here to record issuance.
 
-Public evidence:
+The contract was created at address `0x11ef46e76ae5fbd0b14e29ac7b1fd93ad5ea01f9`. Issuing during contract creation is sometimes called a constructor-path mint. It proves that this particular operation completed on the test network.
 
-- **Minting wallet:** `0xf9e9633D6f23dEa639B64c5A16b5BB22636599B9`
-- **GalileoToken:** `0x11ef46e76ae5fbd0b14e29ac7b1fd93ad5ea01f9`
-- **GalileoCompliance:** `0x688e071B5C7C09c7A9aA6fF0fdd204AD8a7a95Ee`
-- **Mint transaction:** [`0x9cca203f8c3d988ac79bd5ea5c17cfd23a76d0d1393f32e0fb0f82875ccbc026`](https://sepolia.basescan.org/tx/0x9cca203f8c3d988ac79bd5ea5c17cfd23a76d0d1393f32e0fb0f82875ccbc026)
+A reader can use the receipt to distinguish an executed transaction from a planned feature. It says nothing on its own about the authenticity, ownership or condition of a physical object.
 
-The current verified path is intentionally narrow: it proves the on-chain minting capability before expanding the dashboard/API workflow into a full role-gated production flow.
+## What remains a separate demonstration
 
----
+Creating a product through an application involves more than sending this transaction. The application must establish the caller's permissions, apply the intended product rules and return a record that the recipient can use.
 
-## What Remains Before Full API Minting
+The [project changelog](https://github.com/originlabs-app/galileo-protocol/blob/main/CHANGELOG.md) distinguishes this milestone from the remaining identity-role administration needed for the full API-driven flow. That distinction matters when evaluating the system: a successful low-level operation is evidence for one part of the journey.
 
-The next blockchain gate is identity role administration. Operators still need to grant the minting wallet the minimum roles required to operate the identity infrastructure:
+For example, a fictional brand could use a test record to explore how a product identifier appears in a scanner. Before using the same process commercially, it would also need to demonstrate who may create the record, how errors are corrected and how the identifier remains associated with the physical product.
 
-- `REGISTRY_ADMIN_ROLE` on `GalileoTrustedIssuersRegistry`
-- `AGENT_ROLE` on `GalileoIdentityRegistry`
+## Use the evidence at its proper scope
 
-Once these grants are executed, the identity setup can be re-run from the minting wallet and the API path can move from simulated minting to a real, compliance-checked Base Sepolia transaction.
+Keep the transaction as a reproducible technical milestone. Ask for a separate demonstration of any wider workflow on which your business intends to rely.
 
----
+## Frequently asked questions
 
-## Public Repository Hygiene
+### Was this a production sale of a physical product?
 
-The open-source readiness pass is complete. The repository documentation now separates public evidence from private operator material:
+No. The cited transaction is on Base Sepolia, a test network. It records contract creation and token issuance, not a sale, physical authentication or a complete customer journey.
 
-- Public addresses, contract addresses, and transaction hashes are documented.
-- Local environment files remain ignored by Git.
-- Mnemonics and private keys are not documented in the website, roadmap, changelog, or Git-tracked files.
-- Wallet recovery material must stay in an offline backup or password manager, never in a prompt, chat, public note, or repository file.
-
-This keeps the project useful for public review without exposing operational secrets.
-
----
-
-## Next Milestones
-
-The immediate roadmap is now focused on finishing role administration, running the full API-driven mint, and validating the product flow in a browser from dashboard creation through QR scanner verification.
-
-After that, the next larger product goal is enterprise readiness: multi-tenant workspace hardening, webhook delivery history, richer audit exports, API key management, and a clearer brand onboarding path.
+The [Galileo documentation](/docs) provides the next starting point for understanding product records, identity and supported interfaces.

--- a/website/content/blog/2026-08-02-ai-ready-teams-luxury-dpp-era.mdx
+++ b/website/content/blog/2026-08-02-ai-ready-teams-luxury-dpp-era.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'AI-Ready Teams: The Key to Luxury''s DPP Transition'
 date: '2026-08-02'
-author: 'Pierre Beunardeau — Guest post, Origin Education (Origin Labs ecosystem)'
+author: 'Pierre Beunardeau, Guest post, Origin Education (Origin Labs ecosystem)'
 excerpt: >-
   AI can help teams prepare product-passport data. Learn what staff should
   verify, how to handle missing evidence and where training makes a difference.

--- a/website/content/blog/2026-08-02-ai-ready-teams-luxury-dpp-era.mdx
+++ b/website/content/blog/2026-08-02-ai-ready-teams-luxury-dpp-era.mdx
@@ -1,9 +1,13 @@
 ---
-title: "AI-Ready Teams: The Key to Luxury's DPP Transition"
-date: "2026-08-02"
-author: "Pierre Beunardeau — Guest post, Origin Education (Origin Labs ecosystem)"
-excerpt: "Digital Product Passports are a data challenge before they are a blockchain challenge. The maisons that succeed will be the ones whose teams know how to work with AI on data quality, authentication workflows and client experience."
-description: "Digital Product Passports are a data challenge before a blockchain challenge. The maisons that succeed will have teams trained to work with AI."
+title: 'AI-Ready Teams: The Key to Luxury''s DPP Transition'
+date: '2026-08-02'
+author: 'Pierre Beunardeau — Guest post, Origin Education (Origin Labs ecosystem)'
+excerpt: >-
+  AI can help teams prepare product-passport data. Learn what staff should
+  verify, how to handle missing evidence and where training makes a difference.
+description: >-
+  AI can help teams prepare product-passport data. Learn what staff should
+  verify, how to handle missing evidence and where training makes a difference.
 tags:
   - guest-post
   - ai
@@ -11,60 +15,61 @@ tags:
   - training
   - industry
 published: true
+modified: '2026-09-12'
+faq:
+  - question: Can AI decide whether product information is ready for a passport?
+    answer: >-
+      AI can help extract and compare information, but the responsible team must
+      decide whether the evidence supports the claim. Missing or conflicting
+      supplier information needs follow-up, not a plausible generated answer.
+  - question: Does every luxury product need a DPP in 2027?
+    answer: >-
+      No. EU requirements depend on the product group and the applicable rules.
+      Identify the category and its timetable before treating a proposed data
+      field or deadline as mandatory.
 ---
+Teams preparing Digital Product Passports need to know where product information comes from and how to check it. AI can help them extract and compare documents, but a person still needs to resolve missing evidence before the business makes a claim.
 
-## The DPP Deadline Is a People Deadline
+A Digital Product Passport, or DPP, gives access to specified information about a product. It is a data-management task before it becomes a choice of QR code, software or blockchain.
 
-The EU's ESPR regulation will make Digital Product Passports mandatory for regulated goods from 2027. Most conversations about this transition focus on infrastructure: which standard, which chain, which schema. Galileo Protocol exists precisely to answer those questions in the open.
+## Start with a document the team already receives
 
-But there is a second, quieter deadline hiding inside the first one. A Digital Product Passport is only as good as the data your teams feed into it. Provenance records, material declarations, repair histories, authentication events: every field is captured, checked or enriched by a human being somewhere in the maison, from the atelier to after-sales.
+Consider a fictional leather-goods company preparing information for one bag model. A supplier document names a material, while an internal product sheet uses a different description.
 
-And those human beings are, right now, largely untrained for the tools that will define their next decade.
+An AI assistant could highlight the mismatch and identify the relevant passages. That saves the employee from searching each document manually. It does not establish which description is correct. The employee needs to contact the supplier or consult the authoritative specification, then record the answer and its source.
 
-## The Skills Gap Is Measured, Not Anecdotal
+Training should make that handoff familiar. Staff need to recognise the difference between a quotation from a document, an inference and an answer the model cannot support. They also need approved tools and clear rules for the information those tools may receive.
 
-A Microsoft France study published in February 2026 puts numbers on what many luxury operations leaders already sense: 61% of employees who use AI at work do so through personal accounts at least once a week, outside any corporate framework, and 71% of non-executive managers have received no AI training at all.
+## What the available survey actually says
 
-Transpose that to a luxury house preparing DPPs. The teams describing products, verifying supplier declarations and answering client questions are already using generative AI, informally and invisibly. Untrained usage on unmanaged accounts is exactly the wrong setup for an industry whose entire value proposition is trust, confidentiality and provenance.
+[Microsoft France's study published on 12 February 2026](https://news.microsoft.com/source/emea/2026/02/etude-microsoft-france-lusage-de-lia-progresse-dans-les-entreprises-francaises-mais-se-heurte-a-un-manque-daccompagnement/?lang=fr) surveyed 657 private-sector managers and executives through YouGov in January.
 
-## Where AI Actually Helps a DPP Workflow
+Among AI users surveyed, 61% used personal accounts at least weekly. The study also reported that 71% of non-executive managers had received no AI training. Those findings concern the surveyed population, not all workers or luxury brands specifically.
 
-Working alongside brands and technical teams in the Origin Labs ecosystem, which supports the Galileo Protocol project, we see four places where AI-literate teams change the economics of a passport programme:
+The practical question for a company is therefore local: are employees using a tool the company supports, and can they check the result? A training session is more useful when it answers that question with an actual document workflow.
 
-1. **Data quality at the source.** Large language models are remarkably good at spotting inconsistencies between a supplier certificate, a material declaration and a product sheet, before that inconsistency is sealed into a passport. A trained operator with the right prompts catches in minutes what an audit would catch in months.
+## Teach the checks before increasing the volume
 
-2. **Authentication operations.** Fraud patterns evolve faster than manual review guidelines. Teams that know how to use AI to summarise case files, compare authentication events and draft escalation reports process more volume without diluting judgement. The judgement itself stays human; that is the entire point of training.
+For the fictional bag, the employee should be able to follow each proposed statement back to its source. If two documents disagree, the record should preserve the disagreement until someone resolves it.
 
-3. **Client-facing storytelling.** A passport is also a narrative surface: craftsmanship, materials, repair history. Client advisors who master AI drafting tools turn raw traceability data into the kind of story a collector actually wants to read, in the brand's voice, in any language.
+A useful exercise asks staff to prepare a short product record containing both supported information and a deliberately missing field. The successful result is an accurate record with a visible gap and a next step. Filling every field with plausible text would conceal the problem.
 
-4. **Compliance documentation.** ESPR, GDPR and the EU AI Act each come with documentation duties. AI-assisted drafting, with human validation, is the difference between a compliance team that scales and one that drowns.
+Keep customer and supplier information within the permissions of the chosen system. The exact data-protection and other legal requirements depend on the processing involved; an AI-generated document does not establish compliance.
 
-None of this requires a data science department. It requires structured training on real cases, clear rules about what data may enter which tool, and a governance framework the whole team understands.
+## Match preparation to the product timetable
 
-## What "AI-Ready" Looks Like in Practice
+The [European Commission's guidance for economic operators](https://single-market-economy.ec.europa.eu/single-market/digital-product-passport/economic-operators_en) describes requirements developing by product group. There is no single 2027 deadline for all luxury products.
 
-The pattern that works is consistent across industries, and luxury is no exception:
+A company can improve its source records now without pretending that every future passport field is settled. Start with one product, one responsible employee and one exchange with a supplier. Extend the process when the team can explain both the information and its limits.
 
-- **Start from the workflow, not the tool.** Train the after-sales team on their repair documentation, not on generic chatbot demos.
-- **Put data rules before prompts.** Which product data, client data and supplier data may be used with which AI service is a governance decision, taken before the first workshop, and the EU's regulators expect user training as part of any serious deployment.
-- **Measure adoption at 30 and 90 days.** A training that does not change how the passport data is produced was a presentation, not a training.
+## Frequently asked questions
 
-France concentrates a significant share of the world's luxury production and craftsmanship, which makes the training question concrete rather than theoretical: ateliers, after-sales teams and client advisors need programmes built on their own workflows and data rules, delivered where they work. That is the model behind [in-company AI training programmes](https://www.origin.education/lp/formation-ia-intra-entreprise) as practised in the French market: per-role curricula, real cases, and data governance taught as part of the skill rather than as an afterthought. The same philosophy that drives Galileo Protocol, open standards, verifiable claims and human craftsmanship at the centre, applies to how teams should meet AI.
+### Can AI decide whether product information is ready for a passport?
 
-## One Ecosystem, Three Kinds of Proof
+AI can help extract and compare information, but the responsible team must decide whether the evidence supports the claim. Missing or conflicting supplier information needs follow-up, not a plausible generated answer.
 
-This conviction did not appear in a vacuum. Origin Labs contributes technical assistance and development support to Galileo Protocol, alongside project steward Galileo Network, and much of that engineering is done with AI-assisted development practices: the productivity behind several of the protocol's features owes a great deal to them. Origin Labs also backs Origin Education, a certified training centre that teaches exactly those practices, AI automation and AI-assisted software engineering, to companies. Galileo Protocol is thus one of three projects in the same ecosystem that all answer the same question, "how do you make a claim verifiable?", in three different domains:
+### Does every luxury product need a DPP in 2027?
 
-- **Proof of product.** Galileo Protocol gives luxury goods an open, interoperable passport: provenance and craftsmanship as verifiable claims rather than marketing statements.
-- **Proof of compliance.** [AeroCert](https://aerocert.co) applies the same logic to aviation and battery compliance records, issuing and verifying them with zero-knowledge privacy, so that a regulator can check a claim without exposing the underlying data.
-- **Proof of skill.** Origin Education closes the loop on the human side: every trainee leaves with an assessed, certificate-backed validation of what they can actually do, from prompt engineering to AI-assisted software development, the "vibe coding" practice used to build these very products.
+No. EU requirements depend on the product group and the applicable rules. Identify the category and its timetable before treating a proposed data field or deadline as mandatory.
 
-Three domains, one design principle: a claim that cannot be verified is a liability, whether it is stitched into a handbag, filed with a regulator or written on a CV. Teams trained to work with AI are what keep all three kinds of proof honest, because every passport, record and certificate begins as data produced by a person.
-
-## Standards for Products, Skills for People
-
-The luxury industry is converging on a simple truth: authenticity infrastructure and workforce capability are two halves of the same transition. A perfect passport filled by an untrained team will carry perfect-looking errors. A trained team without an open standard will produce beautiful data silos.
-
-Galileo Protocol addresses the second problem in the open. The first one is solved maison by maison, team by team, and it starts earlier than most transformation roadmaps assume: not with the technology choice, but with the people who will use it every day.
-
-*Pierre Beunardeau is co-founder of Origin Labs, which provides technical support to the Galileo Protocol project, and of [Origin Education](https://www.origin.education/), a Qualiopi-certified corporate AI training organisation based in France.*
+Explore the [Galileo documentation](/docs) for the product-record architecture that this work may need to support.

--- a/website/content/blog/2026-08-25-eu-dpp-registry-live.mdx
+++ b/website/content/blog/2026-08-25-eu-dpp-registry-live.mdx
@@ -1,10 +1,14 @@
 ---
-title: "EU DPP Registry Is Live: What Luxury Brands Must Do Now"
-date: "2026-08-25"
-modified: "2026-08-26"
-author: "Pierre Beunardeau"
-excerpt: "The European Commission's central Digital Product Passport registry opened on 20 July 2026, and the first CEN-CENELEC DPP standards were published on 27 May 2026. Not mandatory for luxury yet — here is the decision framework, the readiness grid and the pilot plan to run before your category's delegated act lands."
-description: "The EU Digital Product Passport registry opened on 20 July 2026 and the first CEN-CENELEC DPP standards are out. Timeline and action plan for luxury brands."
+title: 'EU DPP Registry: What Luxury Brands Can Prepare'
+date: '2026-08-25'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  The EU product-passport registry opened in July 2026. Understand what it
+  stores, which rules still depend on the product and how to prepare.
+description: >-
+  The EU product-passport registry opened in July 2026. Understand what it
+  stores, which rules still depend on the product and how to prepare.
 tags:
   - dpp
   - espr
@@ -12,206 +16,62 @@ tags:
   - luxury
   - compliance
 published: true
-coverImage: "/images/blog/eu-dpp-registry-live.jpg"
-coverImageAlt: "Luxury handbag under a cyan holographic digital product passport made of glowing data layers, on a dark obsidian background"
+coverImage: /images/blog/eu-dpp-registry-live.jpg
+coverImageAlt: >-
+  Luxury handbag under a cyan holographic digital product passport made of
+  glowing data layers, on a dark obsidian background
 faq:
-  - question: "Is the EU Digital Product Passport mandatory for luxury goods today?"
-    answer: "No. The central DPP registry opened on 20 July 2026 as infrastructure, but product-level obligations arrive through ESPR delegated acts adopted per product group, and none covers luxury categories yet. The digital battery passport is first, from 18 February 2027 under the Battery Regulation; the delegated act for textiles is expected around 2027. What is already binding for large enterprises since 19 July 2026 is the ban on destroying unsold textiles and footwear."
-  - question: "What is the EU DPP registry?"
-    answer: "It is the central registry required by Article 13 of the ESPR (Regulation (EU) 2024/1781). Operated by the European Commission, it stores the identifiers of Digital Product Passports and lets customs authorities and market surveillance verify that a product has a valid passport."
-  - question: "What standards define the technical format of a DPP?"
-    answer: "The first six harmonised European standards for the DPP were published by CEN and CENELEC on 27 May 2026 (the EN 18xxx family from CEN/CLC/JTC 24). They cover unique identifiers, data carriers, interoperability and access rights, and were cited in the Official Journal by Commission Implementing Decision (EU) 2026/1736 in July 2026, which gives them presumption of conformity with the ESPR."
-  - question: "Does the DPP requirement apply to watches, leather goods and jewelry?"
-    answer: "Yes, in principle. The ESPR covers virtually all physical products placed on the EU market, with only a few exemptions such as food and medicinal products. The exact timing and data requirements for each luxury category will be set by product-specific delegated acts, with textiles among the first priorities of the ESPR working plan."
-  - question: "What should a luxury brand do first to prepare for the DPP?"
-    answer: "Start with data: consolidate product identifiers, bills of materials, provenance and repair records into structured, shareable data. Then align with the published CEN-CENELEC standards and run a pilot on one product line before the delegated act for your category lands."
+  - question: Does the EU registry store the complete product passport?
+    answer: >-
+      No. The central registry stores identifiers and specified metadata.
+      Detailed passport information remains with economic operators or their
+      service providers.
+  - question: Does the registry launch make every luxury passport mandatory?
+    answer: >-
+      No. The obligations and timing depend on the applicable product rules. A
+      working registry is part of the infrastructure, not a universal deadline
+      for every luxury product.
 ---
+The EU Digital Product Passport registry is available, but its opening does not make a passport mandatory for every luxury product. Brands can prepare reliable product records now while checking the rules and timetable for their own category.
 
-The Digital Product Passport is **not mandatory for luxury goods today** — no maison is yet legally required to issue one. But the registry that will host passports and the standards that will define them became real this summer, so the rational move for any brand selling into the EU is to structure its product data and run a pilot now, rather than rebuild under deadline pressure when a delegated act finally names its category.
+The [European Commission announced the registry on 20 July 2026](https://single-market-economy.ec.europa.eu/news/digital-product-passport-registry-now-live-2026-07-20_en). That announcement followed the 19 July date set for establishing it in the Ecodesign for Sustainable Products Regulation, or ESPR.
 
-## The decision you actually face
+## A registry is a directory, not the whole product file
 
-Strip away the news cycle and the choice in front of a luxury maison is binary:
+A Digital Product Passport, or DPP, makes specified product information available through a data carrier such as a QR code. The [Commission's registry explanation](https://single-market-economy.ec.europa.eu/single-market/digital-product-passport/dpp-registry_en) separates the central identifiers and metadata from the detailed information held by operators or their providers.
 
-- **Start now**: consolidate product data, align it with the published CEN-CENELEC standards, and pilot a passport on one product line while the rules for your category are still being drafted.
-- **Wait**: do nothing until a delegated act imposes the obligation, then execute a data, IT and supplier programme inside whatever transition period the act grants.
+For a brand, this means that registering an identifier does not solve hosting, access or backup. Someone must remain responsible for the product information a customer or authority expects to reach.
 
-The cost of waiting is not a fine — there is nothing to be fined for yet. It is three more concrete things. First, the delegated acts will be drafted around the standards already published, so early adopters face no redesign risk while late movers inherit a template they had no hand in testing. Second, the battery passport becomes mandatory in February 2027 and will set the operational reference — data formats, registry workflows, customs practice — against which every later category is measured; watching it go live without internal capability means learning from press releases instead of from your own pilot. Third, DPP readiness is mostly a data-consolidation project, and data consolidation is the part with the longest lead time in any maison: identifiers scattered across PLM and ERP systems, provenance held in supplier PDFs, repair history trapped in after-sales databases. That work takes quarters, not weeks, regardless of when the legal clock starts.
+Consider a fictional footwear company. Its printed code leads to a passport service containing the relevant product data. If that service closes, an identifier in the EU registry does not recreate the missing documents. The company needs a recoverable copy and a way to keep the original link useful.
 
-## What actually changed this summer
+## What is established, and what depends on the product
 
-Three milestones turned the DPP from policy into infrastructure.
+The Commission's launch announcement confirms six harmonised standards supporting the technical architecture. Harmonised standards can support a presumption of conformity for the requirements they cover. They do not certify an entire business or settle every future passport obligation.
 
-**The central registry is open.** On **20 July 2026**, the European Commission opened the central DPP registry, meeting the legal deadline of 19 July 2026 set by Article 13 of the [ESPR — Regulation (EU) 2024/1781](https://eur-lex.europa.eu/eli/reg/2024/1781/oj). The registry is the backbone of the system: it stores passport identifiers and lets customs and market-surveillance authorities verify that a product entering the EU has a valid passport. The implementing rules governing how the registry operates took effect in early August 2026.
+The [Commission's DPP page](https://single-market-economy.ec.europa.eu/single-market/digital-product-passport_en), consulted on 12 September 2026, still includes indicative dates for further work. Product-specific rules determine such matters as required information, access and the level at which a passport applies.
 
-**The technical standards are published.** On **27 May 2026**, CEN and CENELEC published the first six harmonised European standards for the DPP — the EN 18xxx family developed by [CEN/CLC/JTC 24](https://www.cencenelec.eu/areas-of-work/cen-cenelec-topics/ecodesign-labelling-and-traceability-of-products/labelling-and-traceability-of-products/) under Commission mandate M/604. They fix the technical layer: unique product identifiers, data carriers, data exchange and storage, access APIs, interoperability, and access rights for different stakeholder categories. In July 2026 they were cited in the Official Journal through [Commission Implementing Decision (EU) 2026/1736](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L_202601736), which gives them legal weight: a DPP built on these standards benefits from a **presumption of conformity** with the ESPR. According to the [EU Digital Product Passport Foundation](https://eudigitalproductpassport.org/updates/cencenelec-dpp-standards), the family spans eight modular standards — six published, with two further security standards still completing the formal process — covering identifiers (EN 18219), data carriers (EN 18220) and the exchange, storage and API layers around them.
+A model-level record, a batch record and a record for one individual item serve different purposes. Do not assume that every product must use the most detailed option, or that the same fields will apply across a brand's catalogue.
 
-**The first product-specific obligation is already binding.** Since **19 July 2026**, large enterprises are banned from destroying unsold apparel, clothing accessories and footwear under Article 25 of the ESPR. It is the first product-specific ESPR obligation to bite, it touches fashion maisons directly, and it signals where enforcement attention is heading: textiles first, everything else on a rolling calendar.
+## Prepare one usable product record
 
-## Is the DPP mandatory for luxury today? No — and then by sector waves
+Start with the category you intend to place on the market. Follow the [Commission's guidance for economic operators](https://single-market-economy.ec.europa.eu/single-market/digital-product-passport/economic-operators_en) to identify the relevant rules rather than choosing a deadline from a general presentation.
 
-This is the question every board asks, and it deserves a straight answer in the body of the article, not just in the FAQ.
+Then work through one product with the teams that already know its materials, suppliers and service history. Name the source for each statement and the person who can resolve a discrepancy. Where a future field is not settled, label it as preparation rather than a present legal requirement.
 
-**Today, no.** Nothing in the ESPR requires a watchmaker, jeweler, leather-goods house or art market actor to issue a product passport right now. The ESPR is a framework regulation: it creates the passport system and empowers the Commission to impose it, but product-level obligations only exist once a **delegated act** is adopted for a specific product group, with its own data requirements and transition period. As of this writing, no delegated act covers any luxury category.
+Finally, ask a prospective provider to show how the record can be corrected, exported and read by the intended recipient. Agree which data should be public and which requires controlled access. A complete bill of materials or public supplier list may be useful in a particular project; neither should become a universal legal instruction without checking the applicable rule.
 
-**Tomorrow, yes — category by category.** The mechanism is already loaded. The first ESPR working plan, adopted on **16 April 2025**, set the priorities for 2025–2030: textiles and apparel are among the first product groups targeted, alongside furniture, tyres and mattresses, with iron, steel and aluminium also in the early waves (see the [Commission's ESPR page](https://commission.europa.eu/energy-climate-change-environment/standards-tools-and-labels/products-labelling-rules-and-requirements/ecodesign-sustainable-products-regulation_en)). And one product-level passport obligation is already scheduled outside the ESPR: the **digital battery passport** becomes mandatory on **18 February 2027** under Article 77 of the [EU Battery Regulation (EU) 2023/1542](https://eur-lex.europa.eu/eli/reg/2023/1542/oj) — the reference implementation every other category will be measured against.
+## Make the first decision reversible
 
-Two consequences for maisons. First, scope is not the question: the ESPR covers virtually all physical goods placed on the EU market, with only narrow exemptions such as food and medicinal products — watches, leather goods, jewelry and art are in. Second, "not mandatory today" does not mean "not actionable today". The standards the delegated acts will reference are published and carry presumption of conformity; the registry that customs will query is live; the destruction ban shows the Commission is willing to let obligations bite before any passport exists. The unknown is the date and the exact dataset for your category, not the direction.
+Choose an initial exchange you can test with reliable data. Retain control over the records and printed links so that learning from the exercise does not depend on keeping one supplier forever.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 514" role="img" aria-label="Timeline of the EU Digital Product Passport calendar: 16 April 2025, the first ESPR working plan sets the 2025 to 2030 priorities with textiles among the first product groups; 27 May 2026, CEN and CENELEC publish the first six harmonised DPP standards of the EN 18xxx family; July 2026, the standards are cited in the Official Journal by Implementing Decision (EU) 2026/1736, gaining presumption of conformity; 19 July 2026, the ban on destroying unsold textiles and footwear becomes binding for large enterprises; 20 July 2026, the European Commission opens the central DPP registry; early August 2026, the registry implementing rules take effect; 18 February 2027, the digital battery passport becomes mandatory; around 2027, the textiles delegated act is expected, shown as a dashed marker because it is an expectation, not a law." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="28" fontSize="14" fontWeight="600" fill="#FFFFFF">The DPP calendar: from working plan to first obligations</text>
-    <line x1="108" y1="48" x2="108" y2="500" stroke="#062840" strokeWidth="2" />
-    <text x="96" y="68" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">16 Apr 2025</text>
-    <circle cx="108" cy="64" r="4.5" fill="#00FFFF" />
-    <text x="126" y="63" fontSize="12" fill="rgba(255, 255, 255, 0.75)">First ESPR working plan: 2025-2030</text>
-    <text x="126" y="78" fontSize="12" fill="rgba(255, 255, 255, 0.75)">priorities, textiles among first groups</text>
-    <text x="96" y="128" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">27 May 2026</text>
-    <circle cx="108" cy="124" r="4.5" fill="#00FFFF" />
-    <text x="126" y="123" fontSize="12" fill="rgba(255, 255, 255, 0.75)">First six CEN-CENELEC DPP standards</text>
-    <text x="126" y="138" fontSize="12" fill="rgba(255, 255, 255, 0.75)">published (EN 18xxx family)</text>
-    <text x="96" y="188" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">Jul 2026</text>
-    <circle cx="108" cy="184" r="4.5" fill="#00FFFF" />
-    <text x="126" y="183" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Standards cited in the Official Journal,</text>
-    <text x="126" y="198" fontSize="12" fill="rgba(255, 255, 255, 0.75)">giving presumption of conformity</text>
-    <text x="96" y="248" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">19 Jul 2026</text>
-    <circle cx="108" cy="244" r="4.5" fill="#00FFFF" />
-    <text x="126" y="243" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Ban on destroying unsold textiles and</text>
-    <text x="126" y="258" fontSize="12" fill="rgba(255, 255, 255, 0.75)">footwear binds large enterprises</text>
-    <text x="96" y="308" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">20 Jul 2026</text>
-    <circle cx="108" cy="304" r="4.5" fill="#00FFFF" />
-    <text x="126" y="303" fontSize="12" fill="rgba(255, 255, 255, 0.75)">European Commission opens the central</text>
-    <text x="126" y="318" fontSize="12" fill="rgba(255, 255, 255, 0.75)">DPP registry</text>
-    <text x="96" y="368" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">Early Aug 2026</text>
-    <circle cx="108" cy="364" r="4.5" fill="#00FFFF" />
-    <text x="126" y="368" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Registry implementing rules take effect</text>
-    <text x="96" y="428" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">18 Feb 2027</text>
-    <circle cx="108" cy="424" r="4.5" fill="#00FFFF" />
-    <text x="126" y="428" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Digital battery passport mandatory</text>
-    <text x="96" y="488" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">c. 2027</text>
-    <circle cx="108" cy="484" r="4.5" fill="none" stroke="#22D3EE" strokeWidth="1.5" strokeDasharray="3 2" />
-    <text x="126" y="483" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Textiles delegated act expected:</text>
-    <text x="126" y="498" fontSize="12" fill="rgba(255, 255, 255, 0.75)">an expectation, not a law</text>
-  </svg>
-</div>
+## Frequently asked questions
 
-## What a DPP will contain
+### Does the EU registry store the complete product passport?
 
-The ESPR defines the DPP as a digital identity card for products, components and materials. The precise dataset is set per product group by each delegated act, but the framework and the published standards converge on a common core:
+No. The central registry stores identifiers and specified metadata. Detailed passport information remains with economic operators or their service providers.
 
-- **A unique product identifier**, linked to a data carrier on the product (QR code, NFC tag, RFID) and registered in the central registry.
-- **Product and material information**: technical performance, materials and their origin, substances of concern, recycled content.
-- **Circularity data**: repairability, availability of spare parts, disassembly and recycling instructions.
-- **Compliance information**: the declarations and documents demonstrating conformity with the applicable delegated act.
-- **Access-controlled visibility**: consumers, repairers, recyclers, customs and market-surveillance authorities each see the slice of the passport they are entitled to — a requirement the EN 18xxx standards make concrete, and the one that matters most to maisons protective of trade secrets and supplier lists.
+### Does the registry launch make every luxury passport mandatory?
 
-For luxury, this maps naturally onto what maisons already track — serial numbers, certificates, service history, provenance — but in a structured, interoperable, machine-readable form. The hard part is rarely the technology. It is the data: decades of product information scattered across PLM systems, ERP exports, atelier records and after-sales spreadsheets.
+No. The obligations and timing depend on the applicable product rules. A working registry is part of the infrastructure, not a universal deadline for every luxury product.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 398" role="img" aria-label="Conceptual diagram of an EU Digital Product Passport. A data carrier on the product, such as a QR code, NFC tag or RFID chip, links to the passport itself: a unique product identifier registered in the central EU registry. Access is controlled per stakeholder: consumers, repairers, recyclers, customs and market-surveillance authorities each see only the slice of the passport they are entitled to. Conceptual schematic based on the ESPR framework described in this article, not a final legal dataset." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="28" fontSize="14" fontWeight="600" fill="#FFFFFF">Anatomy of a DPP: carrier, registry, access slices</text>
-    <text x="220" y="52" textAnchor="middle" fontSize="10.5" fill="rgba(255, 255, 255, 0.4)">Data carrier on the product</text>
-    <rect x="79" y="58" width="86" height="26" rx="13" fill="rgba(0, 255, 255, 0.06)" stroke="#22D3EE" strokeWidth="1" />
-    <text x="122" y="75" textAnchor="middle" fontSize="11.5" fill="#22D3EE">QR code</text>
-    <rect x="177" y="58" width="86" height="26" rx="13" fill="rgba(0, 255, 255, 0.06)" stroke="#22D3EE" strokeWidth="1" />
-    <text x="220" y="75" textAnchor="middle" fontSize="11.5" fill="#22D3EE">NFC tag</text>
-    <rect x="275" y="58" width="86" height="26" rx="13" fill="rgba(0, 255, 255, 0.06)" stroke="#22D3EE" strokeWidth="1" />
-    <text x="318" y="75" textAnchor="middle" fontSize="11.5" fill="#22D3EE">RFID</text>
-    <line x1="220" y1="88" x2="220" y2="106" stroke="#22D3EE" strokeWidth="1.5" />
-    <polygon points="215,102 225,102 220,110" fill="#22D3EE" />
-    <rect x="60" y="112" width="320" height="62" rx="10" fill="#041c30" stroke="rgba(0, 255, 255, 0.35)" strokeWidth="1" />
-    <text x="220" y="140" textAnchor="middle" fontSize="14" fontWeight="600" fill="#FFFFFF">Digital Product Passport</text>
-    <text x="220" y="160" textAnchor="middle" fontSize="11" fill="rgba(255, 255, 255, 0.7)">Unique identifier, registered in the central registry</text>
-    <line x1="220" y1="174" x2="220" y2="196" stroke="#062840" strokeWidth="2" />
-    <text x="220" y="212" textAnchor="middle" fontSize="10.5" fill="rgba(255, 255, 255, 0.4)">Each stakeholder sees only its slice</text>
-    <rect x="60" y="224" width="320" height="26" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="78" y="241" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Consumers</text>
-    <rect x="312" y="233" width="52" height="8" rx="4" fill="rgba(0, 255, 255, 0.35)" />
-    <rect x="60" y="258" width="320" height="26" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="78" y="275" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Repairers</text>
-    <rect x="312" y="267" width="52" height="8" rx="4" fill="rgba(0, 255, 255, 0.35)" />
-    <rect x="60" y="292" width="320" height="26" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="78" y="309" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Recyclers</text>
-    <rect x="312" y="301" width="52" height="8" rx="4" fill="rgba(0, 255, 255, 0.35)" />
-    <rect x="60" y="326" width="320" height="26" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="78" y="343" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Customs</text>
-    <rect x="312" y="335" width="52" height="8" rx="4" fill="rgba(0, 255, 255, 0.35)" />
-    <rect x="60" y="360" width="320" height="26" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="78" y="377" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Market surveillance</text>
-    <rect x="312" y="369" width="52" height="8" rx="4" fill="rgba(0, 255, 255, 0.35)" />
-  </svg>
-</div>
-
-## The readiness grid: data, standards, pilot
-
-The tool below is how we recommend structuring preparation. Three columns, applied to each workstream: **what data to consolidate, which standard layer to align it with, and how to test it in a pilot**. It works with the ESPR framework and the published EN 18xxx standards as they exist today, before any luxury delegated act exists.
-
-| Workstream | Data: what to prepare | Standards: what to align to | Pilot: how to test it |
-| --- | --- | --- | --- |
-| Unique product identity | One serial/identifier scheme per item, deduplicated across ERP, PLM and after-sales | Unique identifier + data carrier standards (EN 18xxx identifier and carrier layers) | Tag one product line with QR or NFC; scan at every handover for a full season |
-| Materials and composition | Bill of materials per SKU, including hardware and packaging, with supplier origin | ESPR product-information fields as framed by the framework regulation | Complete the BOM for the pilot line to 100% of components — no "TBD" tolerated |
-| Provenance and chain of custody | Supplier certificates and lot records in structured form, not PDFs in inboxes | Interoperability and data-exchange layers of the EN 18xxx family | Digitise the certificate flow for the pilot line's top five suppliers |
-| Service and repair history | Repair events linked to the product identifier, with actor and date | Access-rights model: repairers see the service slice, not the full passport | Log every after-sales intervention on the pilot line against the passport |
-| Circularity | Repairability information, spare-parts availability, end-of-life instructions | ESPR circularity parameters as defined for your category's future act | Publish repair and care data in the consumer-facing view of the pilot passport |
-| Confidentiality and access | A map of who may see what: consumer, repairer, recycler, customs, authority | Access-control and security requirements of the standards | Role-test the passport: what a client sees vs. what a customs officer sees |
-
-And the Monday-morning checklist to launch it:
-
-1. Appoint one owner for DPP readiness — this fails as a shared responsibility.
-2. Inventory where product identifiers live today (ERP, PLM, after-sales, e-commerce) and measure the overlap.
-3. Pick one pilot line: iconic enough to matter, small enough to control.
-4. Freeze the identifier scheme for that line and choose the data carrier (QR, NFC, or both).
-5. Complete the bill of materials for the pilot line, supplier by supplier.
-6. Link after-sales records to identifiers, even manually at first.
-7. Define the access matrix: what the consumer, the repairer and the authority may each see.
-8. Run the pilot for a full sales season and write down what broke — that document is your head start when the delegated act arrives.
-
-## Applying the grid: a bounded case
-
-Take an illustrative mid-size leather-goods maison — three product lines, roughly 40,000 units a year, two ateliers, most sales in the EU. The figures are fictional; the data gaps are the ones we consistently see.
-
-- **Identity**: serials exist in the ERP but after-sales uses a different numbering; step 1 is a mapping table, not new software.
-- **Materials**: the BOM is complete for leather and lining, incomplete for hardware and adhesives; two suppliers provide composition data only as PDF certificates. The pilot forces structured capture for one line.
-- **Provenance**: tannery certificates exist per lot but are not linked to individual products. The pilot links lots to serials at assembly.
-- **Service**: repair records exist but are keyed to customer accounts, not products. Relinking them to serials is the single highest-value data task, because service history is what makes a passport useful on the resale market.
-- **Access**: the maison wants clients to see authenticity, materials and care; repairers to see construction and spare parts; and nobody to see the supplier list. The access-rights layer of the standards handles this natively.
-
-Six months of pilot on 5,000 units of one line produces three assets the maison keeps whatever the delegated act says: a clean identifier backbone, a structured dataset for its flagship line, and an internal team that has issued and used real passports. When the act for its category lands, the compliance conversation becomes "extend what works", not "start a programme".
-
-## What the texts do not say
-
-Intellectual honesty about the current state of play:
-
-- **No luxury delegated act exists.** The exact dataset, data carrier and transition period for watches, jewelry or leather goods are not yet written anywhere. Any vendor claiming to sell a "fully compliant luxury DPP" today is selling alignment with published standards, which is valuable but is not certified compliance.
-- **The textile date is an expectation, not a law.** The delegated act for textiles is widely expected around 2027; the working plan sets priorities, not binding adoption dates. Plan against the priority order, not against a rumoured month.
-- **Two standards are still in the pipeline.** Per the EU DPP Foundation, the two security-related standards of the EN 18xxx family were still completing their formal process after the first six were published. Security and access control are exactly the layers maisons care most about — track them.
-- **SME treatment is unclear.** Delegated acts may include simplified requirements or longer transitions for smaller companies, but nothing is guaranteed until the acts exist.
-- **Enforcement economics are unknown.** Penalties are set by member states under the ESPR's national enforcement provisions; market-surveillance practice around the registry will take time to become predictable.
-
-## Galileo's take
-
-**Galileo's take: the DPP will be won on data discipline, not on technology procurement.** Every maison will eventually be able to buy a passport tool; not every maison will have twenty years of clean, structured product data to pour into it. The winners will be the brands that treat the passport as a customer-facing asset — proof of authenticity, a service record, a resale enabler — and recover the compliance cost through trust and secondary-market value. The losers will treat it as a regulatory tax and pay it twice: once to comply, once to catch up with competitors who turned the same data into a client experience. Starting the data work now is a low-regret move under every plausible scenario: the standards are fixed, the registry is live, and the only variable left is the date.
-
-*Galileo Protocol is an open protocol for product identity and the tokenization of physical assets: each item gets a verifiable digital twin, authenticity and service events are recorded as interoperable attestations, and personal data stays off-chain. The schemas are published openly in our [specifications](/specifications), so a maison can pilot a full passport lifecycle — issue, authenticate, service, resell — against the standards that now carry presumption of conformity. Explore the [documentation](/docs) or [contact us](mailto:info@galileoprotocol.io) to discuss a pilot.*
-
-## FAQ
-
-### Is the EU Digital Product Passport mandatory for luxury goods today?
-
-No. The central registry opened on 20 July 2026 as infrastructure, but product-level obligations arrive through ESPR delegated acts per product group, and none covers luxury categories yet. The battery passport is first, from 18 February 2027; the delegated act for textiles is expected around 2027. What is already binding for large enterprises is the ban on destroying unsold textiles and footwear, since 19 July 2026.
-
-### What is the EU DPP registry?
-
-The central registry required by Article 13 of the ESPR, operated by the European Commission. It stores the identifiers of Digital Product Passports and lets customs and market-surveillance authorities verify that a product has a valid passport.
-
-### What standards define the technical format of a DPP?
-
-The first six harmonised European standards, published by CEN and CENELEC on 27 May 2026 (the EN 18xxx family from CEN/CLC/JTC 24) and cited in the Official Journal by Commission Implementing Decision (EU) 2026/1736. They cover identifiers, data carriers, interoperability and access rights, and carry presumption of conformity with the ESPR.
-
-### Does the DPP requirement apply to watches, leather goods and jewelry?
-
-Yes, in principle. The ESPR covers virtually all physical products placed on the EU market. The timing and data requirements for each luxury category will be set by product-specific delegated acts, with textiles among the first priorities.
-
-### What should a luxury brand do first?
-
-Start with data: consolidate product identifiers, bills of materials, provenance and repair records into structured, shareable data. Then align with the published CEN-CENELEC standards and run a pilot on one product line before your category's delegated act lands.
+The [Galileo documentation](/docs) explains product-record concepts; our [provider-exit guide](/blog/2026-09-11-dpp-provider-exit) develops the continuity questions to ask before signing a contract.

--- a/website/content/blog/2026-08-25-mica-transitional-period-rwa.mdx
+++ b/website/content/blog/2026-08-25-mica-transitional-period-rwa.mdx
@@ -1,138 +1,85 @@
 ---
-title: "MiCA Transition Ends: RWA Tokenization Leaves the Grey Zone"
-date: "2026-08-25"
-modified: "2026-08-25"
-author: "Pierre Beunardeau"
-excerpt: "Since 1 July 2026, the MiCA transitional period has ended across the entire EU: no authorisation, no service. Here is the decision framework — which rulebook applies to your token — a reusable scoping checklist, a bounded luxury case, and what MiCA deliberately leaves open, with care for LEOX holders."
-description: "The MiCA grandfathering window closed on 1 July 2026 across the EU as on-chain RWAs hit $33.5 billion. What changes for tokenization, luxury and LEOX."
+title: 'MiCA After the Transition: Which Rules Fit Your Token?'
+date: '2026-08-25'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  The MiCA transition has ended. Check the rights in your token, the service
+  being offered and the relevant authorisation or notification route.
+description: >-
+  The MiCA transition has ended. Check the rights in your token, the service
+  being offered and the relevant authorisation or notification route.
 tags:
   - mica
   - rwa
   - tokenization
   - regulation
-  - leox
 published: true
 faq:
-  - question: "When did the MiCA transitional period end?"
-    answer: "Everywhere in the EU on 1 July 2026 at the latest. Article 143(3) of Regulation (EU) 2023/1114 allowed CASPs already operating under national law before 30 December 2024 to continue until they were granted or refused a MiCA authorisation, or until 1 July 2026, whichever came first. Member states could shorten that window: several (including the Netherlands, Finland, Hungary, Latvia, Poland and Slovenia) chose six months, ending 30 June 2025, and others chose twelve months, ending 30 December 2025."
-  - question: "Does MiCA regulate tokenized real-world assets?"
-    answer: "It depends on the legal nature of the token. Crypto-assets that qualify as financial instruments under MiFID II are excluded from MiCA's scope and fall under securities law, including the EU DLT Pilot Regime (Regulation (EU) 2022/858). Other tokenized assets — asset-referenced tokens, e-money tokens and utility tokens — are directly in MiCA's scope, as are the services around them: custody, exchange, trading platforms and advice."
-  - question: "What concretely changed for crypto service providers on 1 July 2026?"
-    answer: "The situation became binary: a provider either holds a CASP authorisation granted under Article 63 of MiCA by a national competent authority — valid across the whole EU through passporting — or it must cease providing crypto-asset services to EU clients. ESMA maintains an interim register of authorised CASPs and of non-compliant entities."
-  - question: "Does MiCA apply to luxury goods tokenization and Digital Product Passports?"
-    answer: "Not directly to the passport itself. A Digital Product Passport or authenticity certificate is product data governed by the ESPR, not a crypto-asset. MiCA becomes relevant when tokens linked to physical goods are offered or traded as crypto-assets, or when regulated services — custody, exchange, transfer — are provided around them. The two frameworks are complementary: ESPR standardises the product data layer, MiCA standardises the market conduct layer."
-  - question: "Does full MiCA application mean a token like LEOX is 'approved' by the EU?"
-    answer: "No. MiCA does not approve or endorse individual crypto-assets. White papers are notified to competent authorities, not validated by them, and ESMA states this explicitly on its register. Regulatory clarity defines the rules of the game; it says nothing about the merits or future value of any token. Nothing in this article is investment advice."
+  - question: Must every crypto-asset service provider obtain a new MiCA licence?
+    answer: >-
+      An in-scope provider needs a lawful route to provide the service. MiCA
+      provides both CASP authorisation and a notification route for eligible
+      financial institutions. Ending the transition does not remove that
+      distinction.
+  - question: Does a token linked to one physical product fall outside MiCA?
+    answer: >-
+      Not automatically. Examine the rights, transferability and economic
+      characteristics. The exclusion for unique, non-fungible crypto-assets is
+      substantive; an individual identifier alone does not settle the
+      classification.
+  - question: Does every public token offer need a white paper?
+    answer: >-
+      No. Article 4 contains exemptions for the assets within its scope, with
+      conditions and limits. Where a white paper is required, the applicable
+      notification, publication and marketing sequence must be followed.
 ---
+The end of MiCA's maximum transitional period means an existing provider can no longer rely on that temporary route to continue an in-scope service. To evaluate a token project, first identify the holder's rights and the service being offered; the word “tokenization” does not select the rulebook.
 
-Since 1 July 2026, the first question for any tokenization project touching the EU is no longer "is this allowed?" but "which rulebook applies to this token?" — and that question must be answered by a legal qualification exercise done before any technical or commercial decision. The cost of skipping it is now binary: the services around your token are either provided by authorised entities, or they cannot be provided to EU clients at all.
+MiCA is the EU Markets in Crypto-Assets Regulation. A crypto-asset service provider, often shortened to CASP, is a business providing one of the services covered by that regulation.
 
-## What ended on 1 July 2026
+## What changed on 1 July 2026
 
-[MiCA — Regulation (EU) 2023/1114](https://eur-lex.europa.eu/eli/reg/2023/1114/oj) entered into force in June 2023. Its stablecoin titles applied from 30 June 2024 and the full regulation from 30 December 2024. But one clause kept a door half-open: **Article 143(3)**, the grandfathering provision. It allowed crypto-asset service providers (CASPs) already operating legally under national regimes before 30 December 2024 to continue "until 1 July 2026 or until they are granted or refused an authorisation pursuant to Article 63, whichever is sooner."
+MiCA allowed eligible existing providers to continue temporarily under national transitional arrangements. Those periods could be shorter than the EU maximum. The [ESMA country matrix](https://www.esma.europa.eu/sites/default/files/2024-12/List_of_MiCA_grandfathering_periods_art._143_3.pdf) records the arrangements and conditions; it is not evidence that any particular business was eligible.
 
-That window was deliberately non-uniform. Member states could shorten it or skip it entirely, and they did: the Netherlands, Finland, Hungary, Latvia, Poland and Slovenia opted for six months (closed 30 June 2025), others — Spain among them — for twelve months (closed 30 December 2025). **1 July 2026 was the hard outer limit, everywhere.** The [European Securities and Markets Authority (ESMA)](https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica) published the list of national grandfathering periods, maintains the interim register of authorised CASPs — and now also lists non-compliant entities.
+The maximum window ended on 1 July 2026. A provider's current permissions now matter more than its past presence in the market.
 
-The situation is therefore binary since that date: authorised under Article 63 by a national competent authority, with an EU-wide passport, or out of the EU market. For eighteen months, "MiCA compliance" was a roadmap item; it is now an operating condition. Any platform, custodian or exchange still serving EU clients without authorisation is not in a grey zone — it is on the wrong side of a bright line that ESMA's register makes publicly checkable.
+That does not mean every provider must obtain the same new licence. [ESMA's explanation of articles 59 and 60](https://www.esma.europa.eu/print/pdf/node/207695), published on 12 September 2024, distinguishes CASP authorisation from notification by eligible financial institutions. Check the institution, service and permitted route before accepting a claim that a provider may operate.
 
-## Where RWA tokenization stood when the window closed
+## Start with what the customer actually receives
 
-The timing matters because the market did not wait for the rules. According to the [Stobox State of RWA Tokenization — 2026 Mid-Year Report](https://www.stobox.io/reports/state-of-rwa-2026) (data as of 10 July 2026):
+A digital product record may contain care information. Another token may give its holder a right to redeem a stored object. A third may provide an investment interest. These arrangements can use similar technology while creating different rights.
 
-- **$33.5 billion** of on-chain RWA value excluding stablecoins (rwa.xyz methodology, July 2026) — roughly **4× the level of early 2025**.
-- Close to **995,000 on-chain RWA holders** across 167 tokenization platforms and 30+ networks.
-- Ethereum remains the centre of gravity with **47.9%** of RWA value.
-- The largest segments are tokenized US Treasuries and money-market funds ($13.4–15.2 billion) and private credit ($8–18.9 billion depending on methodology).
+[MiCA article 2](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-2-scope) sets the scope and exclusions. Financial instruments are excluded from MiCA because a different regulatory framework applies. Unique, non-fungible crypto-assets also have a specific exclusion. A unique serial number alone is not enough to determine the result.
 
-The same report lists "MiCA's transitional period ends across the EU" as one of July 2026's regulatory milestones — alongside the first tokenization company IPO and ERC-7943 reaching Final status as an Ethereum RWA standard. It also carries an honest caveat worth repeating: **issuance is not liquidity**. Much of the tokenized credit and Treasury market still operates in mint-and-redeem cycles rather than genuine secondary trading. Regulatory clarity removes the "is this allowed?" question; it does not manufacture a market. Keep that caveat in mind — it returns in the limits section below.
+Electronic-money tokens are not simply outside MiCA. The article's exclusion for funds expressly distinguishes those tokens. Avoid classifications based only on an asset's marketing name or the fact that something physical exists behind it.
 
-## The first decision: which rulebook applies to your token
+## Work through a physical-product example
 
-This is where most commentary goes wrong, and it is where a tokenization project should spend its first legal euro.
+Consider a fictional company proposing a token associated with one watch. Before discussing its legal category, write down whether the holder can redeem that particular watch, transfer the token, receive income or share rights with other holders.
 
-MiCA defines a crypto-asset broadly — a digital representation of a value or of a right that can be transferred and stored electronically using distributed-ledger technology (Article 3(1)(5)). If a token cannot be transferred to other holders at all, it falls outside the definition itself. From there, the regulation works by **exclusion**: MiCA regulates crypto-assets *not already covered by other EU financial services law* — see the [European Commission's digital finance page](https://finance.ec.europa.eu/digital-finance/crypto-assets_en).
+Then identify who stores the watch, who owes the holder a duty and who offers custody or transfer services. A supplier's statement that the project has no investment promise does not replace this analysis. Equally, an object identifier used only to read a product record should not be treated as an investment merely because it is called a token.
 
-Per **Article 2(4)** of the regulation, MiCA does not apply to crypto-assets that qualify as:
+The output should be a description that a qualified adviser can assess. Do not label the same arrangement both excluded as unique and regulated as an ordinary utility-token offer without explaining the alternative assumptions.
 
-- **financial instruments** as defined by [MiFID II — Directive 2014/65/EU](https://eur-lex.europa.eu/eli/dir/2014/65/oj): transferable securities, money-market instruments, units in collective investment undertakings, derivatives. A tokenized security stays a security — it is governed by securities law and, for DLT-based market infrastructure, by the [DLT Pilot Regime — Regulation (EU) 2022/858](https://eur-lex.europa.eu/eli/reg/2022/858/oj), in application since March 2023;
-- **deposits and structured deposits**;
-- **funds**, except where they qualify as e-money tokens;
-- **securitisation positions** — pooling and tranching tokenized assets is [Regulation (EU) 2017/2402](https://eur-lex.europa.eu/eli/reg/2017/2402/oj) territory, not MiCA's;
-- **insurance, reinsurance and pension products**.
+## Follow the relevant offer rules
 
-Per **Article 2(3)**, crypto-assets that are **unique and not fungible** with other crypto-assets are also out of scope — the NFT carve-out. It comes with an explicit anti-circumvention warning in the regulation's recitals: issuing assets in a large series or collection is an indicator of fungibility, and fractionalising a unique asset brings the fractions back into scope. The label on the token does not decide; its actual characteristics do.
+For crypto-assets within the relevant title II regime, [article 4](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-4-offers-public-crypto-assets-other) sets public-offer conditions and exemptions. Check those conditions before saying a white paper is always required.
 
-What MiCA covers directly is everything left: **asset-referenced tokens** (ARTs), **e-money tokens** (EMTs), and the broad residual category of "other" crypto-assets — including **utility tokens** — plus every service around them: custody and administration, exchange, operation of trading platforms, execution of orders, advice, portfolio management, transfer services.
+Where required under that regime, [article 8](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-8-notification-crypto-asset-white) provides for notification rather than prior approval of the white paper. That statement must not be extended to every category of crypto-asset. Our [Bitpanda analysis](/blog/2026-09-03-mica-bitpanda-marketing-paper-trail) explains the associated marketing sequence.
 
-To help authorities and market participants draw the brightest of these lines, ESMA published its **Guidelines on the conditions and criteria for the qualification of crypto-assets as financial instruments** (final report, December 2024 — referenced on [ESMA's MiCA page](https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica)). The guidelines matter because the MiFID/MiCA boundary is the most consequential fork in the checklist below: a token that drifts into financial-instrument territory leaves MiCA entirely and inherits prospectus, conduct and market-infrastructure obligations instead.
+## Frequently asked questions
 
-## Checklist: is your token inside MiCA's perimeter?
+### Must every crypto-asset service provider obtain a new MiCA licence?
 
-A reusable scoping exercise, in the order the questions should be asked. It is a reading grid, not legal advice — the final qualification belongs to counsel in the relevant member state.
+An in-scope provider needs a lawful route to provide the service. MiCA provides both CASP authorisation and a notification route for eligible financial institutions. Ending the transition does not remove that distinction.
 
-1. **Is it a crypto-asset at all?** Digital representation of value or a right, transferable and storable via DLT (Art. 3(1)(5)). A non-transferable certificate — say, a product passport locked to the item — is not a crypto-asset. If it cannot move, stop here: outside MiCA.
-2. **Is it genuinely unique and non-fungible?** If yes, Art. 2(3) takes it out — unless it is fractionalised, or issued as part of a series or collection in a way that makes the "unique" label artificial. Both bring it back in.
-3. **Does it qualify as a MiFID II financial instrument?** Does it confer ownership or debt claims, profit participation, voting or dividend-like rights, or exposure to an underlying? If yes: outside MiCA; securities law applies, and any DLT trading or settlement infrastructure should look at the DLT Pilot Regime. Use the ESMA guidelines as the reference text for this step.
-4. **Is it e-money, a deposit, a fund unit, a securitisation position, or an insurance/pension product?** Each has its own regime listed in Art. 2(4). If yes: outside MiCA, into that regime.
-5. **If none of the above: it is in MiCA.** Now classify it. Pegged to a single official currency → e-money token. Maintaining value by referencing other values, rights or currencies → asset-referenced token. Everything else — including utility tokens that grant access to a good or service → the residual category, with a white paper to notify before any public offer or admission to trading.
-6. **Who does what around it?** Custody, exchange, platform operation, advice, transfers: each is a regulated crypto-asset service requiring CASP authorisation under Article 63 — since 1 July 2026, without exception. Map every actor in your value chain to this list.
-7. **Where do the two rails meet?** If the token also carries product data (authenticity, provenance, service history), the ESPR/DPP framework governs that data layer independently. Both can apply to the same object without conflict — one to the data, one to the market conduct.
+### Does a token linked to one physical product fall outside MiCA?
 
-## Applying the checklist: tokenizing a luxury watch
+Not automatically. Examine the rights, transferability and economic characteristics. The exclusion for unique, non-fungible crypto-assets is substantive; an individual identifier alone does not settle the classification.
 
-A bounded case, deliberately concrete. A maison wants to issue, for each watch of a flagship line (5,000 units a year), a transferable digital twin used for authentication, service history, and ownership transfer on resale. Walk the checklist:
+### Does every public token offer need a white paper?
 
-1. **Crypto-asset?** Yes — the twin is transferable by design and stored on a DLT. Had the maison made it non-transferable (a pure passport bound to the watch forever), the exercise would stop here: ESPR territory only, no MiCA.
-2. **Unique and non-fungible?** Each twin is tied to one physical watch with a unique serial — the Art. 2(3) carve-out is plausibly available. But two design choices would destroy it: selling **fractions** of a twin (100 investors each holding 1% of a watch), or minting thousands of interchangeable twins marketed as an investment collection. The first is clearly fractionalisation; the second is exactly the "series or collection" indicator the recitals flag.
-3. **Financial instrument?** If the twin is marketed with an expectation of profit — "buy the twin, watches appreciate, we will help you resell" — counsel must test it against transferable-security and collective-investment criteria using the ESMA guidelines. If it is a pure proof of authenticity and ownership with no investment promise, it stays clear of MiFID.
-4. **E-money, deposit, securitisation?** No — as long as nobody pools watches into tranches.
-5. **Classification:** the twin, if fungibility questions are resolved, lands in MiCA's residual category as a utility-type crypto-asset; a public offer triggers the white-paper notification obligation.
-6. **Actors:** if the maison — or more realistically a specialised platform — offers custody of the twins, or runs a resale marketplace where they are exchanged, those are CASP services. Since 1 July 2026, that platform must be authorised. The maison's vendor-selection question is no longer "who has the best tech?" but "who is on ESMA's register?".
-7. **Two rails:** the watch's passport data (materials, service history) lives under the ESPR; the twin's circulation lives under MiCA. Same object, two defined rulebooks — which is precisely what "the grey zone is closed" means in practice.
+No. Article 4 contains exemptions for the assets within its scope, with conditions and limits. Where a white paper is required, the applicable notification, publication and marketing sequence must be followed.
 
-The same physical watch can therefore sit under three different regimes — outside MiCA entirely, inside MiCA as a utility token, or outside MiCA as a financial instrument — depending entirely on how the token is designed and marketed. That is why the qualification exercise comes first.
-
-## What MiCA does not settle
-
-The regulation closes the authorisation question. It deliberately, or by silence, leaves several others open:
-
-- **Liquidity.** MiCA licenses intermediaries; it does not create buyers. As the Stobox report notes, much of the $33.5 billion on-chain RWA market still runs mint-and-redeem rather than genuine secondary trading. A compliant token with no market is a compliant token with no market.
-- **Securitisation.** Pooling tokenized assets — luxury portfolios included — into tranches sits under Regulation (EU) 2017/2402, with its own due-diligence, risk-retention and transparency rules. MiCA neither enables nor simplifies it.
-- **NFT edge cases.** The Art. 2(3) carve-out is assessed case by case. Fractional NFTs are in scope; large "collections" may be too. Projects that relabel fungible tokens as NFTs to escape MiCA are exactly what the recitals warn against, and ESMA has signalled it will look through the label.
-- **No approval, no endorsement.** MiCA does not certify tokens. White papers are *notified* to national authorities, not validated by them, and ESMA states this explicitly on its register. "MiCA compliant" on a website is a claim, not a credential.
-- **Decentralisation.** Services provided in a fully decentralised manner, without any intermediary, fall outside MiCA — but "fully" is doing heavy lifting, and the regulation gives no bright-line test. Most real-world projects have an identifiable operator and cannot rely on this.
-- **Supervisory convergence.** Authorisation is national (Article 63), passporting is EU-wide, but supervisory practice across 27 authorities will take years to converge. The rulebook is uniform; its enforcement culture is not yet.
-
-## What this changes for LEOX holders
-
-With care, and without any form of financial advice: the end of the transitional period does not "approve" LEOX or any other token. MiCA does not work that way — white papers are notified, not endorsed, and ESMA says so explicitly on its register.
-
-What holders and users of a utility token in a tokenization ecosystem actually gain is structural: the intermediaries they interact with operate under a single EU rulebook; the classification questions that made platforms hesitant are settled by published guidelines; and building consumer-facing services on utility tokens is now a compliance exercise with known parameters rather than a legal bet. Clarity is an operating condition. It is not a promise about value, and nothing in this article constitutes investment advice.
-
-## Galileo's take
-
-**Galileo's take: in the post-transition market, the moat is not the token — it is the qualification file.** Every serious project will soon have access to the same authorised custodians, the same exchanges, the same passported infrastructure. What will separate durable tokenization projects from relaunches is whether the legal nature of the token was decided deliberately, documented against the ESMA guidelines, and designed to survive the Art. 2(3)/2(4) fork without rebranding. The projects that treated compliance plumbing as a first-class design constraint before July 2026 are now building; the ones that treated it as a launch blocker are rewriting white papers. For physical-asset tokenization specifically, we read the ESPR/MiCA split as a feature, not a burden: product truth on one rail, market conduct on the other, and no ambiguity about which rulebook owns which question.
-
-*Galileo Protocol is an open protocol for the authenticity and tokenization of physical assets — luxury goods first — with transferable digital twins, verifiable identity and compliance rules encoded at the token level, designed for exactly this two-rail world of ESPR product data and MiCA market conduct. Explore the [Galileo documentation](/docs) to see how a standards-based tokenization flow works end to end, or [contact us](mailto:info@galileoprotocol.io) to discuss what post-MiCA clarity means for your project. Nothing in this article is investment advice.*
-
-## FAQ
-
-### When did the MiCA transitional period end?
-
-Everywhere in the EU on 1 July 2026 at the latest. Article 143(3) allowed pre-existing CASPs to continue until their authorisation was granted or refused, or until that date, whichever came first. Several member states shortened the window to six months (closed 30 June 2025) or twelve months (closed 30 December 2025).
-
-### Does MiCA regulate tokenized real-world assets?
-
-It depends on the token's legal nature. Tokens qualifying as financial instruments under MiFID II are excluded from MiCA and fall under securities law, including the DLT Pilot Regime. Asset-referenced tokens, e-money tokens and utility tokens — and all services around them — are in MiCA's scope.
-
-### What concretely changed for crypto service providers on 1 July 2026?
-
-The situation became binary: authorised under Article 63 of MiCA — with EU-wide passporting — or out of the EU market. ESMA maintains the register of authorised CASPs and of non-compliant entities.
-
-### Does MiCA apply to luxury goods tokenization and Digital Product Passports?
-
-Not to the passport itself, which is ESPR territory. MiCA applies when tokens linked to physical goods are offered or traded as crypto-assets, or when regulated services are provided around them. The two frameworks are complementary.
-
-### Does full MiCA application mean a token like LEOX is "approved" by the EU?
-
-No. MiCA does not approve or endorse crypto-assets; white papers are notified, not validated. Regulatory clarity defines the rules of the game and says nothing about any token's merits or future value. This article is not investment advice.
+Before choosing infrastructure, establish the rights, responsible parties and lawful service route. Use the [Galileo documentation](/docs) to explore the technical record only after those business choices are clear.

--- a/website/content/blog/2026-08-25-mica-transitional-period-rwa.mdx
+++ b/website/content/blog/2026-08-25-mica-transitional-period-rwa.mdx
@@ -25,9 +25,9 @@ faq:
   - question: Does a token linked to one physical product fall outside MiCA?
     answer: >-
       Not automatically. Examine the rights, transferability and economic
-      characteristics. The exclusion for unique, non-fungible crypto-assets is
-      substantive; an individual identifier alone does not settle the
-      classification.
+      characteristics. The exclusion concerns crypto-assets that are unique
+      and non-fungible, meaning not interchangeable with other crypto-assets.
+      An individual identifier alone does not settle the classification.
   - question: Does every public token offer need a white paper?
     answer: >-
       No. Article 4 contains exemptions for the assets within its scope, with
@@ -50,7 +50,7 @@ That does not mean every provider must obtain the same new licence. [ESMA's expl
 
 A digital product record may contain care information. Another token may give its holder a right to redeem a stored object. A third may provide an investment interest. These arrangements can use similar technology while creating different rights.
 
-[MiCA article 2](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-2-scope) sets the scope and exclusions. Financial instruments are excluded from MiCA because a different regulatory framework applies. Unique, non-fungible crypto-assets also have a specific exclusion. A unique serial number alone is not enough to determine the result.
+[MiCA article 2](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-2-scope) sets the scope and exclusions. Financial instruments are excluded from MiCA because a different regulatory framework applies. Crypto-assets that are unique and non-fungible, meaning not interchangeable with other crypto-assets, also have a specific exclusion. A unique serial number alone is not enough to determine the result.
 
 Electronic-money tokens are not simply outside MiCA. The article's exclusion for funds expressly distinguishes those tokens. Avoid classifications based only on an asset's marketing name or the fact that something physical exists behind it.
 
@@ -64,7 +64,9 @@ The output should be a description that a qualified adviser can assess. Do not l
 
 ## Follow the relevant offer rules
 
-For crypto-assets within the relevant title II regime, [article 4](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-4-offers-public-crypto-assets-other) sets public-offer conditions and exemptions. Check those conditions before saying a white paper is always required.
+The offer rules discussed here are in title II, the part of MiCA for crypto-assets other than asset-referenced tokens or electronic-money tokens. [Article 4](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-4-offers-public-crypto-assets-other) sets public-offer conditions and exemptions.
+
+A [white paper](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-6-content-and-form-crypto-asset) is the public document explaining the project, the token holder's rights and obligations, and the risks. Check the article 4 conditions before assuming every offer needs one.
 
 Where required under that regime, [article 8](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-8-notification-crypto-asset-white) provides for notification rather than prior approval of the white paper. That statement must not be extended to every category of crypto-asset. Our [Bitpanda analysis](/blog/2026-09-03-mica-bitpanda-marketing-paper-trail) explains the associated marketing sequence.
 
@@ -76,7 +78,7 @@ An in-scope provider needs a lawful route to provide the service. MiCA provides 
 
 ### Does a token linked to one physical product fall outside MiCA?
 
-Not automatically. Examine the rights, transferability and economic characteristics. The exclusion for unique, non-fungible crypto-assets is substantive; an individual identifier alone does not settle the classification.
+Not automatically. Examine the rights, transferability and economic characteristics. The exclusion concerns crypto-assets that are unique and non-fungible, meaning not interchangeable with other crypto-assets. An individual identifier alone does not settle the classification.
 
 ### Does every public token offer need a white paper?
 

--- a/website/content/blog/2026-08-26-lvmh-dpp-strategy.mdx
+++ b/website/content/blog/2026-08-26-lvmh-dpp-strategy.mdx
@@ -38,7 +38,7 @@ A Digital Product Passport, or DPP, connects a product to information that autho
 
 ## What LVMH and Aura have published
 
-[LVMH's official DPP page](https://www.lvmh.com/en/commitment-in-action/for-the-environment/digital-product-passport) describes pilots launched through LIFE 360 in 2024 and a progressive approach to future European requirements.
+[LVMH's official DPP page](https://www.lvmh.com/en/commitment-in-action/for-the-environment/digital-product-passport) says the group continued deployment in 2024 under its LIFE 360 environmental strategy. It describes an initial rollout in pilot Maisons, without dating their launch, followed by plans for gradual expansion across the group.
 
 Separately, [Aura's announcement of 28 April 2026](https://auraconsortium.com/news/stefano-rosso-appointed-chairman-aura-blockchain-consortium) reports more than 50 brands and more than 80 million registered products. These are figures declared by the consortium. They are not a count of LVMH products, and registration volume does not measure the quality of every customer journey.
 

--- a/website/content/blog/2026-08-26-lvmh-dpp-strategy.mdx
+++ b/website/content/blog/2026-08-26-lvmh-dpp-strategy.mdx
@@ -1,10 +1,14 @@
 ---
-title: "LVMH's DPP Strategy in Writing: The Signal Luxury Awaited"
-date: "2026-08-26"
-modified: "2026-08-26"
-author: "Pierre Beunardeau"
-excerpt: "LVMH has put its Digital Product Passport strategy in writing: a public commitment page, a group-level DPP Factory, and more than 80 million products registered on the Aura blockchain it co-founded. For every maison that was waiting for a market signal, this is it — here is the decision framework, the infrastructure checklist and the limits of what we actually know."
-description: "LVMH has put its Digital Product Passport strategy in writing. What the move signals for every luxury house still deciding when to build DPP capability."
+title: 'LVMH''s DPP Strategy: Lessons for Other Luxury Brands'
+date: '2026-08-26'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  LVMH describes its product-passport work, while Aura reports consortium-wide
+  adoption. Learn what those sources establish and what a brand should ask.
+description: >-
+  LVMH describes its product-passport work, while Aura reports consortium-wide
+  adoption. Learn what those sources establish and what a brand should ask.
 tags:
   - dpp
   - lvmh
@@ -13,199 +17,61 @@ tags:
   - traceability
   - aura-blockchain
 published: true
-coverImage: "/images/blog/lvmh-dpp-strategy.jpg"
-coverImageAlt: "Craftsman hands working on a luxury watch movement in a dark atelier, with a subtle cyan traceability thread of light"
+coverImage: /images/blog/lvmh-dpp-strategy.jpg
+coverImageAlt: >-
+  Craftsman hands working on a luxury watch movement in a dark atelier, with a
+  subtle cyan traceability thread of light
 faq:
-  - question: "Has LVMH officially announced a Digital Product Passport strategy?"
-    answer: "Yes, in substance. LVMH publishes a dedicated Digital Product Passport page on lvmh.com stating that it deployed the DPP from 2024 under its LIFE 360 environmental strategy, starting with pilot Maisons and extending gradually across the Group. In June 2025, group IT executives detailed a 'DPP Factory' delivering a standardised, turnkey solution to the Maisons. There is no single dated launch event — the strategy is documented as an ongoing, group-level programme rather than announced as news."
-  - question: "Is LVMH's DPP the same thing as the EU regulatory Digital Product Passport?"
-    answer: "No. LVMH's DPP is a voluntary, group-driven initiative that anticipates the EU framework. The regulatory DPP will be imposed product group by product group through delegated acts of the ESPR (Regulation (EU) 2024/1781), and no delegated act covers luxury categories yet. LVMH's page explicitly frames its DPP as a response to future European regulatory requirements, which means its current format may still evolve if and when delegated acts cover its categories."
-  - question: "What is the Aura Blockchain Consortium?"
-    answer: "Aura is a private blockchain consortium co-founded in April 2021 by LVMH, Prada Group and Cartier (Richemont), later joined by OTB and others. In a June 2026 interview, its CEO stated that Aura counts more than 50 member brands and more than 80 million products registered on its blockchain, spanning fashion, jewelry, beauty and wines and spirits."
-  - question: "Does a luxury house need to join Aura to be DPP-ready?"
-    answer: "No. The future legal obligation is to issue a passport aligned with the ESPR framework and the published CEN-CENELEC standards — not to use a specific vendor or consortium. A house can build on open standards and interoperable protocols, provided its identifiers, data carriers, access rights and data exchange layers align with the standards that carry presumption of conformity. The infrastructure choice should be made on alignment, interoperability, data control and vendor independence."
-  - question: "When will the Digital Product Passport be mandatory for luxury goods?"
-    answer: "No date is set for luxury categories yet. The ESPR is a framework regulation: obligations arrive through delegated acts per product group. Textiles and apparel are among the first priorities of the 2025–2030 working plan, and the digital battery passport — the reference implementation — becomes mandatory on 18 February 2027. Watches, jewelry and leather goods may be covered by later delegated acts; no calendar is published."
+  - question: Are Aura's 80 million registered products all LVMH products?
+    answer: >-
+      No. Aura's April 2026 announcement reports more than 80 million registered
+      products across its consortium. It does not attribute that total to LVMH.
+  - question: Does a brand's DPP pilot establish compliance for other brands?
+    answer: >-
+      No. A pilot can show how a brand approaches product information. Another
+      company must establish its own applicable requirements, data quality and
+      operating arrangements.
 ---
+LVMH's public Digital Product Passport work gives other luxury brands a concrete example of preparing product information. It does not establish that every brand needs the same system, or that a consortium's total registrations belong to LVMH alone.
 
-LVMH has put its Digital Product Passport strategy in writing — publicly, on its corporate website, with named programmes, a dedicated "DPP Factory" and more than 80 million products already registered on the blockchain consortium it co-founded. For every maison that was waiting for a market signal before committing to DPP infrastructure, this is it; the decision on the table now is whether you choose your infrastructure while the standards are still forming, or inherit the choices the leaders are making without you.
+A Digital Product Passport, or DPP, connects a product to information that authorised recipients can access. The useful question for another maison is how that information remains accurate and usable after the initial sale.
 
-## The decision you actually face
+## What LVMH and Aura have published
 
-If you run product, digital or sustainability at a luxury house that has not yet committed to a Digital Product Passport architecture, the LVMH documentation removes the last comfortable excuse for waiting. The question is no longer "will the DPP become real for luxury?" — the market leader is already deploying it voluntarily, at group scale. The question is narrower and harder:
+[LVMH's official DPP page](https://www.lvmh.com/en/commitment-in-action/for-the-environment/digital-product-passport) describes pilots launched through LIFE 360 in 2024 and a progressive approach to future European requirements.
 
-- **Commit now**: select your DPP infrastructure — consortium, open protocol, or a hybrid — while no EU delegated act covers luxury categories yet, and shape your data model around your own priorities.
-- **Keep waiting**: let LVMH, the Aura consortium and the first movers define the de facto reference for what a luxury passport looks like, then align with whatever template the market and the regulator have absorbed by the time your category is named.
+Separately, [Aura's announcement of 28 April 2026](https://auraconsortium.com/news/stefano-rosso-appointed-chairman-aura-blockchain-consortium) reports more than 50 brands and more than 80 million registered products. These are figures declared by the consortium. They are not a count of LVMH products, and registration volume does not measure the quality of every customer journey.
 
-Waiting is a legitimate strategy for regulation with uncertain scope. It is a much weaker strategy once the market leader has moved from piloting to writing the playbook in public — because the playbook being written is the one your future clients, your resale partners and eventually your regulator will compare you against.
+Read the sources at those scopes. The LVMH page describes one group's programme; Aura describes participation in its wider infrastructure. Neither proves a resale-price premium or a universal reduction in authentication work.
 
-## What LVMH actually put in writing
+## Follow the information through a second owner
 
-Three verifiable artefacts make up the signal. None of them is a press release dated this month — and that is precisely the point, as we discuss in the limits section below.
+Consider a fictional maison preparing a passport for a bag. At the first sale, the record might help the customer find care instructions. At a later repair, the service team needs to know which item it received and what it changed. A subsequent buyer may need evidence of that intervention.
 
-**A public strategy page.** LVMH maintains a dedicated [Digital Product Passport page](https://www.lvmh.com/en/commitment-in-action/for-the-environment/digital-product-passport) in the environmental section of lvmh.com. The language is unambiguous: "the introduction of the Digital Product Passport constitutes a major step forward for LVMH", documenting "every stage of the product life cycle, from raw material origin through to end-of-life solutions, via production, use and repair". The page states that **in 2024 LVMH continued to deploy the DPP** under its LIFE 360 environmental strategy, that it was "initially deployed in a number of pilot Maisons" and "will be further extended gradually across the entire Group", and that it "provides a response to future European regulatory requirements". This is not an experiment described in the conditional tense; it is group policy described in the declarative.
+Those uses require more than an attractive opening page. The maison should know who can add a service record, whether the issuer can correct an error and which details a later owner may see. Customer contact information should not become public merely because it shares a system with product information.
 
-**A DPP Factory.** In a [June 2025 feature published by La Tribune](https://www.latribune.fr/partenaires/la-technologie-pour-un-monde-meilleur/luxe-les-passeports-digitaux-redefinissent-l-excellence-1028607.html) — partner content produced with IBM Consulting, which matters for how you weigh it — Romain Haris, Group IT Back-End & Traceability Director at LVMH, described the group's delivery vehicle: a **DPP Factory** whose "mission is to deliver a complete, turnkey and standardised solution to our Maisons, covering front end and back end", as "an accelerator for implementation and adoption". He framed the core challenge as data, not technology — "collect, compute, communicate" — and confirmed the group advances with pilot divisions and Maisons that "definitively validate the solutions in a real environment" before any technology selection. He also put a number on the demand side: nearly half of LVMH's clients consider the ESG dimension "primordial" in their purchase decision.
+This example is a proposed workflow, not an account of LVMH's implementation.
 
-**Industrial-scale deployment through Aura.** LVMH co-founded the [Aura Blockchain Consortium](https://www.ictjournal.ch/news/2021-04-21/lvmh-prada-et-richemond-lancent-aura-leur-blockchain-pour-lindustrie-du-luxe) in April 2021 with Prada Group and Cartier (Richemont). In a [June 2026 interview with the Journal du Luxe](https://www.journalduluxe.fr/fr/interview/entretien-marcel-hartlein-ceo-aura-blockchain-consortium-vivatech-2026), Aura's CEO Marcel Härtlein stated the consortium now counts **more than 50 member brands and more than 80 million products registered** on its blockchain, and described the industry moment as "a transition from experimentation to implementation", with DPPs moving from pilots to lifecycle services — authentication, after-sales, repair, resale, circularity. The same interview details how Bvlgari moved from a leather-goods pilot to a "Bvlgari Passport" covering all High Jewelry creations, then extended it to its entire watch collection. LVMH's own [LIFE 360 Awards coverage](https://www.lvmh.com/en/news-lvmh/life-360-awards-2025-lvmh-recognizes-13-standout-initiatives-by-its-maisons-to-accelerate-its-environmental-transformation) describes Bvlgari's Connected Jewelry: a micro-engraving on each piece, readable by smartphone, opening a Digital Passport with gemological certificates, origin and craftsmanship.
+## Ask questions that survive a supplier change
 
-Put together: a written group strategy, a dedicated delivery organisation, and an eight-figure count of registered products. That is what "in writing" means.
+Before selecting a provider, ask it to demonstrate one product record through creation, correction and export. Then have a second system read the exported information.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 286" role="img" aria-label="Timeline of the LVMH Digital Product Passport paper trail: April 2021, LVMH co-founds the Aura Blockchain Consortium with Prada Group and Cartier (Richemont); 2024, the DPP is deployed under the LIFE 360 environmental strategy, starting with pilot Maisons; June 2025, group IT executives detail a DPP Factory delivering a turnkey, standardised solution to the Maisons; June 2026, Aura's CEO states the consortium counts more than 50 member brands and more than 80 million products registered, figures that are self-reported." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="28" fontSize="14" fontWeight="600" fill="#FFFFFF">LVMH and Aura: the DPP paper trail</text>
-    <line x1="108" y1="48" x2="108" y2="262" stroke="#062840" strokeWidth="2" />
-    <text x="96" y="68" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">Apr 2021</text>
-    <circle cx="108" cy="64" r="4.5" fill="#00FFFF" />
-    <text x="126" y="63" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Aura Blockchain Consortium co-founded</text>
-    <text x="126" y="78" fontSize="12" fill="rgba(255, 255, 255, 0.75)">with Prada Group and Cartier (Richemont)</text>
-    <text x="96" y="128" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">2024</text>
-    <circle cx="108" cy="124" r="4.5" fill="#00FFFF" />
-    <text x="126" y="123" fontSize="12" fill="rgba(255, 255, 255, 0.75)">DPP deployed under LIFE 360,</text>
-    <text x="126" y="138" fontSize="12" fill="rgba(255, 255, 255, 0.75)">starting with pilot Maisons</text>
-    <text x="96" y="188" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">Jun 2025</text>
-    <circle cx="108" cy="184" r="4.5" fill="#00FFFF" />
-    <text x="126" y="183" fontSize="12" fill="rgba(255, 255, 255, 0.75)">DPP Factory detailed: a turnkey,</text>
-    <text x="126" y="198" fontSize="12" fill="rgba(255, 255, 255, 0.75)">standardised solution for the Maisons</text>
-    <text x="96" y="248" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">Jun 2026</text>
-    <circle cx="108" cy="244" r="4.5" fill="#00FFFF" />
-    <text x="126" y="243" fontSize="12" fill="rgba(255, 255, 255, 0.75)">Aura CEO: 50+ member brands and 80M+</text>
-    <text x="126" y="258" fontSize="12" fill="rgba(255, 255, 255, 0.75)">products registered (self-reported)</text>
-  </svg>
-</div>
+An export is useful only if the recipient understands the identifiers, claims and access rules. If all interpretation depends on a proprietary screen, the brand may still struggle to use its own records elsewhere. Our [provider-exit guide](/blog/2026-09-11-dpp-provider-exit) describes that test in more detail.
 
-## Why this is a market signal, not a compliance story
+Also establish the boundary between a product record and any transferable financial or redemption rights. Transferability alone does not decide whether MiCA applies. The rights and services need their own assessment, as explained in our [MiCA guide](/blog/2026-08-25-mica-transitional-period-rwa).
 
-It would be easy to file all of this under "big group anticipates regulation". That reading misses the mechanism that matters for everyone else.
+## Use the example without copying the scale
 
-**The reference implementation is being set by practitioners, not just by regulators.** The EU will define the legal floor through ESPR delegated acts, and we covered that infrastructure — the central registry, the CEN-CENELEC standards — in our [previous article](/blog/2026-08-25-eu-dpp-registry-live). Those harmonised DPP standards have been published in the Official Journal through [Commission Implementing Decision (EU) 2026/1736](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32026D1736), which is what gives products built to those standards presumption of conformity with the ESPR's DPP requirements. But the legal floor is not what clients will see. What clients will see is the passport experience the leaders ship: what a scan reveals, how service history is presented, how authenticity is proven at resale. When the group that sells a significant share of the world's luxury goods standardises that experience across its Maisons, it sets the expectation every other house will be measured against — including houses three times smaller with no consortium seat.
+The lesson is to make one product's information dependable for the next person who needs it. A small pilot with known sources and a demonstrated handover can answer that question without promising a future resale premium.
 
-**The DPP has ceased to be a niche topic.** When Aura's CEO lists beauty, wines and spirits, and even yachting as growth segments, and when 80 million products carry a registered digital identity, the passport is no longer a sustainability-team experiment. It is becoming ordinary infrastructure — which means the absence of a passport starts to read as a signal in itself, first on the resale market, then at retail.
+## Frequently asked questions
 
-**Data is the moat, and data takes time.** LVMH's own framing — "collect, compute, communicate" — concedes that the hard part is consolidating product data across a value chain. That work is measured in quarters and years, independent of any legal deadline. A house that waits for a delegated act to cover its category will be doing its data consolidation while its competitors are already operating passports. This is the same conclusion we reached from the regulatory side; the LVMH file confirms it from the market side.
+### Are Aura's 80 million registered products all LVMH products?
 
-Two other rails sit next to this one and should not be mixed up. The [EU DPP registry and CEN-CENELEC standards](/blog/2026-08-25-eu-dpp-registry-live) define the legal floor and the technical format. [MiCA's end of transition](/blog/2026-08-25-mica-transitional-period-rwa) defines the market-conduct floor if a passport is also a transferable token. LVMH's file is neither: it is a market signal about what a luxury house is already willing to ship, voluntarily, before either obligation bites its category.
+No. Aura's April 2026 announcement reports more than 80 million registered products across its consortium. It does not attribute that total to LVMH.
 
-## Voluntary DPP vs ESPR floor: what is the same, what is not
+### Does a brand's DPP pilot establish compliance for other brands?
 
-A maison reading LVMH's page and the ESPR in the same sitting will confuse them. They share a vocabulary; they do not share a legal status.
+No. A pilot can show how a brand approaches product information. Another company must establish its own applicable requirements, data quality and operating arrangements.
 
-| Question | LVMH's documented DPP | EU ESPR Digital Product Passport |
-| --- | --- | --- |
-| Legal status | Voluntary group programme, framed as anticipating future EU requirements | Framework regulation (EU) 2024/1781; product-level duties only via delegated acts |
-| Who is bound | LVMH Maisons, under group policy | Any economic operator placing in-scope products on the EU market, once an act names the category |
-| Dataset | Group-defined (lifecycle, origin, repair, end-of-life) | Per product group, set by the delegated act |
-| Technical format | Aura / maison implementations | CEN-CENELEC EN 18xxx family, cited by Implementing Decision (EU) 2026/1736, with presumption of conformity |
-| Timing for luxury | Already in deployment since 2024 in pilot Maisons | No delegated act covers watches, jewelry or leather goods yet |
-| What a client sees | The experience the group ships (scan, service history, resale proof) | Whatever the act requires to be visible to each stakeholder |
-
-The practical consequence: aligning with LVMH's *experience* (a living passport, service events, resale) is a market decision. Aligning with the CEN-CENELEC standards is a regulatory-readiness decision. A house can do the second without joining Aura; it cannot treat the first as a certificate of ESPR compliance.
-
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 360" role="img" aria-label="Comparison diagram. LVMH's documented DPP is a voluntary group programme anticipating EU requirements, running on Aura and maison implementations, deployed since 2024 and shaping the experience clients see. The EU ESPR Digital Product Passport is the legal floor: framework Regulation (EU) 2024/1781 imposes duties only through delegated acts per product group, its technical format is the CEN-CENELEC EN 18xxx standards cited by Implementing Decision (EU) 2026/1736, and no delegated act covers luxury categories yet. The two share vocabulary but have different legal status." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="28" fontSize="14" fontWeight="600" fill="#FFFFFF">Voluntary signal vs legal floor</text>
-    <rect x="20" y="44" width="400" height="116" rx="10" fill="#041c30" stroke="rgba(0, 255, 255, 0.3)" strokeWidth="1" />
-    <text x="36" y="70" fontSize="12.5" fontWeight="600" fill="#00FFFF">LVMH's documented DPP (voluntary)</text>
-    <text x="36" y="92" fontSize="11" fill="rgba(255, 255, 255, 0.7)">Group programme anticipating EU requirements</text>
-    <text x="36" y="110" fontSize="11" fill="rgba(255, 255, 255, 0.7)">Runs on Aura and maison implementations</text>
-    <text x="36" y="128" fontSize="11" fill="rgba(255, 255, 255, 0.7)">Deployed since 2024; shapes the client experience</text>
-    <line x1="220" y1="160" x2="220" y2="180" stroke="#062840" strokeWidth="2" />
-    <text x="220" y="196" textAnchor="middle" fontSize="10.5" fill="rgba(255, 255, 255, 0.4)">Shared vocabulary, different legal status</text>
-    <rect x="20" y="206" width="400" height="140" rx="10" fill="#021020" stroke="rgba(255, 255, 255, 0.12)" strokeWidth="1" />
-    <text x="36" y="232" fontSize="12.5" fontWeight="600" fill="#FFFFFF">EU ESPR passport (legal floor)</text>
-    <text x="36" y="254" fontSize="11" fill="rgba(255, 255, 255, 0.7)">Framework Regulation (EU) 2024/1781:</text>
-    <text x="36" y="272" fontSize="11" fill="rgba(255, 255, 255, 0.7)">duties only via delegated acts per group</text>
-    <text x="36" y="290" fontSize="11" fill="rgba(255, 255, 255, 0.7)">Format: CEN-CENELEC EN 18xxx, cited by</text>
-    <text x="36" y="308" fontSize="11" fill="rgba(255, 255, 255, 0.7)">Implementing Decision (EU) 2026/1736</text>
-    <text x="36" y="326" fontSize="11" fill="rgba(255, 255, 255, 0.7)">No delegated act covers luxury categories yet</text>
-  </svg>
-</div>
-
-## The decision grid: commit now or keep waiting
-
-Here is the choice laid out as we would put it in front of an executive committee.
-
-| Dimension | Commit to infrastructure now | Wait for the delegated act |
-| --- | --- | --- |
-| Standards risk | Low — align with published CEN-CENELEC standards carrying presumption of conformity; adjust at the margins if an act later covers your category | Low on paper, but you inherit whatever interpretations the market has baked in |
-| Market positioning | Passport is still a differentiator; you shape client expectations in your category | Passport becomes table stakes; you match expectations set by competitors |
-| Data readiness | Consolidation starts now, at your own pace, line by line | Consolidation compressed into the act's transition period, under deadline pricing |
-| Resale and services | You capture service history and secondary-market value from day one | Years of service events remain unlinked to products, some lost permanently |
-| Cost profile | Spread over quarters; pilot-scale spend first | Concentrated programme spend, plus integration premium under time pressure |
-| Influence | Your pilot informs how the category's dataset gets discussed | You comment on a template you never tested |
-
-The grid is deliberately unsympathetic to waiting, because the usual argument for waiting — "the requirements are not final" — confuses the legal dataset with the infrastructure. The dataset will be finalised per category; the infrastructure (identifiers, data carriers, access rights, lifecycle events) is already defined well enough to build on.
-
-## The reusable tool: ten questions before you choose your DPP infrastructure
-
-Whether the LVMH signal pushes you to act this quarter or next, the infrastructure decision should be made against explicit criteria. These ten questions work for any house, with or without a consortium invitation:
-
-1. **Standards alignment**: does the solution implement the published CEN-CENELEC DPP standards — unique identifiers, data carriers, interoperability, access rights — or a proprietary format you would have to migrate later?
-2. **Data ownership**: who controls the product data — you, the vendor, or a consortium governance body? Can you export everything, in a documented format, at any time?
-3. **Identifier sovereignty**: are product identifiers yours and resolvable independently of the vendor's platform, or do they die if the contract ends?
-4. **Access rights**: can you show a client, a repairer, a reseller and a customs officer four different views of the same passport, as the standards require?
-5. **Lifecycle coverage**: does the passport record events after the sale — repairs, services, ownership changes — or is it a static certificate frozen at purchase?
-6. **Interoperability**: can your passport exchange data with the systems of your suppliers, your retail partners and the resale platforms your products actually circulate on?
-7. **Confidentiality**: can you keep supplier lists and trade-sensitive data out of the consumer-facing view without weakening the authenticity proof?
-8. **Regulatory upgrade path**: if and when a delegated act covers your category, what exactly changes — a configuration, or a rebuild?
-9. **Vendor independence**: if the vendor or consortium disappears, what still works? The authenticity proof your clients rely on should not depend on one company's uptime or survival.
-10. **Exit cost**: what does it cost, in money and in data, to leave? If the honest answer is "everything", you are not choosing infrastructure — you are signing a lease.
-
-A solution that answers all ten well will still be standing if and when delegated acts reach your category. One that answers five will need to be re-bought.
-
-## Applying the tool: a bounded case
-
-Take an illustrative independent high-jewelry house — around 12,000 pieces a year, one atelier, 60% of sales in the EU, a growing share of pieces resold through specialist platforms. The situation is fictional; the trade-offs are the ones we see in real engagements.
-
-The house is weighing three options. **Joining a consortium** gives it a proven, luxury-native stack and immediate credibility, but on the consortium's governance terms — question 2 and question 10 from the checklist deserve hard answers in writing before signature. **Building on open standards** gives it full data ownership and identifier sovereignty, at the price of assembling and operating more of the stack itself. **Waiting** costs nothing this year and quietly compounds: every piece sold without a passport is a piece whose future service history and resale authentication will have to be reconstructed retroactively, atelier archive by atelier archive.
-
-The house runs the ten questions against both active options. The deciding factor is not technology — both can tag a piece and serve a passport. It is question 5, lifecycle coverage: high jewelry lives for generations, its value at resale depends on documented provenance and service, and the house's own restoration atelier is its strongest trust asset. An infrastructure that cannot record a 2031 repair on a 2027 piece fails the house's core use case regardless of brand. It chooses the option that treats the passport as a living record, starts with one iconic line of 2,000 pieces a year, and keeps the consortium door open from a position of working infrastructure rather than urgency. Bounded conclusion: the LVMH signal did not tell this house *which* infrastructure to pick — it told it to stop treating the choice itself as postponable.
-
-## The limits of what we know
-
-Intellectual honesty about the signal, because a market read is only worth what its evidence supports:
-
-- **There is no fresh, dated LVMH announcement in August 2026.** We looked for one and could not verify any. The strategy page predates this summer — its content references deployment in 2024 — and appears to have been public since at least 2025. This article is therefore an analysis of an established, documented strategy, not coverage of a news event. Any outlet claiming a specific 2026 "officialisation" date should be asked for a primary source.
-- **The La Tribune feature is partner content** produced with IBM Consulting. The LVMH quotes are attributable and specific, but the framing is promotional; we treat the DPP Factory description as factual and the enthusiasm as marketing.
-- **Aura's figures are self-reported.** "More than 50 brands" and "more than 80 million products" come from the consortium's own CEO in an interview, not from an audited disclosure. The order of magnitude is consistent with Aura's public trajectory, but treat the precision as claimed, not certified.
-- **A group strategy page is not a deployment report.** LVMH itself describes pilot Maisons and gradual extension. We do not know what share of the group's 2026 output actually ships with a passport, and neither does the public.
-- **Voluntary is not compliant.** LVMH's DPP anticipates the ESPR; nothing guarantees its current dataset will map one-to-one onto any delegated act that may later cover watches, jewelry or leather goods — none exists yet, and the ESPR 2025–2030 working plan publishes no calendar for these categories. Early movers carry redesign risk too — it is simply smaller than the market risk of arriving late.
-- **A consortium is not a standard.** Aura's scale makes it a de facto reference, not a normative one. The normative layer remains the ESPR and the CEN-CENELEC standards — and aligning with those is open to every house, consortium member or not.
-
-## Galileo's take
-
-**Galileo's take: the LVMH file closes the "wait for a signal" era — and it should be read as a starting gun for infrastructure decisions, not as a verdict in favour of any single consortium.** A group of this scale does not publish a group-level strategy, fund a delivery factory and register tens of millions of products to decorate a sustainability report; it does so because verifiable product identity is becoming core luxury infrastructure, as ordinary within five years as the serial number is today. The lesson for every other house is twofold. First, the market will now differentiate between brands that can prove and brands that can only claim — and that differentiation will show up in resale value before it shows up in regulation. Second, you do not need a consortium seat to move: the standards are published, the registry is live, and open protocols let a house of any size issue passports it fully owns — identifiers, data and lifecycle events — while staying interoperable with whatever the leaders standardise. The houses that will look back on 2026 well are the ones that stopped asking "is the DPP real?" and started asking "which infrastructure do we trust with the next thirty years of our products' history?"
-
-*Galileo Protocol is an open protocol for product identity and the tokenization of physical assets: each item gets a verifiable digital twin, authenticity and service events are recorded as interoperable attestations, and personal data stays off-chain. Our schemas are published openly in our [specifications](/specifications), so a maison can pilot a full passport lifecycle — issue, authenticate, service, resell — without surrendering its data to anyone. Explore the [documentation](/docs) or [contact us](mailto:info@galileoprotocol.io) to discuss a pilot.*
-
-## Sources
-
-- [LVMH, Digital Product Passport](https://www.lvmh.com/en/commitment-in-action/for-the-environment/digital-product-passport): group strategy page, LIFE 360 deployment from 2024, pilot Maisons, response to future European requirements. Consulted 26 August 2026.
-- [La Tribune / IBM Consulting, « Luxe : les passeports digitaux redéfinissent l'excellence »](https://www.latribune.fr/partenaires/la-technologie-pour-un-monde-meilleur/luxe-les-passeports-digitaux-redefinissent-l-excellence-1028607.html), 30 June 2025: partner content; Romain Haris on the DPP Factory. Weigh as attributable quotes in a promotional frame.
-- [Journal du Luxe, interview Marcel Härtlein, Aura Blockchain Consortium](https://www.journalduluxe.fr/fr/interview/entretien-marcel-hartlein-ceo-aura-blockchain-consortium-vivatech-2026), 17 June 2026: self-reported figures, more than 50 brands and 80 million products; Bvlgari passport rollout.
-- [ICT Journal, Aura launch](https://www.ictjournal.ch/news/2021-04-21/lvmh-prada-et-richemond-lancent-aura-leur-blockchain-pour-lindustrie-du-luxe), 21 April 2021: consortium co-founded by LVMH, Prada Group and Cartier (Richemont).
-- [LVMH, LIFE 360 Awards 2025](https://www.lvmh.com/en/news-lvmh/life-360-awards-2025-lvmh-recognizes-13-standout-initiatives-by-its-maisons-to-accelerate-its-environmental-transformation): Bvlgari Connected Jewelry.
-- [ESPR — Regulation (EU) 2024/1781](https://eur-lex.europa.eu/eli/reg/2024/1781/oj) and [Commission Implementing Decision (EU) 2026/1736](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32026D1736): legal floor and citation of CEN-CENELEC DPP standards.
-- [ESPR 2025–2030 working plan](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A52025DC0187): product-group priorities, no luxury calendar.
-
-## FAQ
-
-### Has LVMH officially announced a Digital Product Passport strategy?
-
-Yes, in substance. LVMH publishes a dedicated Digital Product Passport page on lvmh.com stating that it deployed the DPP from 2024 under its LIFE 360 environmental strategy, starting with pilot Maisons and extending gradually across the Group. In June 2025, group IT executives detailed a "DPP Factory" delivering a standardised, turnkey solution to the Maisons. There is no single dated launch event — the strategy is documented as an ongoing, group-level programme rather than announced as news.
-
-### Is LVMH's DPP the same thing as the EU regulatory Digital Product Passport?
-
-No. LVMH's DPP is a voluntary, group-driven initiative that anticipates the EU framework. The regulatory DPP will be imposed product group by product group through delegated acts of the ESPR (Regulation (EU) 2024/1781), and no delegated act covers luxury categories yet. LVMH's page explicitly frames its DPP as a response to future European regulatory requirements, which means its current format may still evolve if and when delegated acts cover its categories.
-
-### What is the Aura Blockchain Consortium?
-
-Aura is a private blockchain consortium co-founded in April 2021 by LVMH, Prada Group and Cartier (Richemont), later joined by OTB and others. In a June 2026 interview, its CEO stated that Aura counts more than 50 member brands and more than 80 million products registered on its blockchain, spanning fashion, jewelry, beauty and wines and spirits.
-
-### Does a luxury house need to join Aura to be DPP-ready?
-
-No. The future legal obligation is to issue a passport aligned with the ESPR framework and the published CEN-CENELEC standards — not to use a specific vendor or consortium. A house can build on open standards and interoperable protocols, provided its identifiers, data carriers, access rights and data exchange layers align with the standards that carry presumption of conformity. The infrastructure choice should be made on alignment, interoperability, data control and vendor independence.
-
-### When will the Digital Product Passport be mandatory for luxury goods?
-
-No date is set for luxury categories yet. The ESPR is a framework regulation: obligations arrive through delegated acts per product group. Textiles and apparel are among the first priorities of the [ESPR 2025–2030 working plan](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A52025DC0187), and the digital battery passport — the reference implementation — becomes mandatory on 18 February 2027. Watches, jewelry and leather goods may be covered by later delegated acts; no calendar is published.
+Explore the [Galileo documentation](/docs) to identify the record formats and responsibilities your own pilot would need.

--- a/website/content/blog/2026-08-27-cbp-louisville-fake-watches-border-enforcement.mdx
+++ b/website/content/blog/2026-08-27-cbp-louisville-fake-watches-border-enforcement.mdx
@@ -1,10 +1,16 @@
 ---
-title: "Louisville's Fake Watch Seizures: What Borders Can't Prove"
-date: "2026-08-27"
-modified: "2026-09-01"
-author: "Pierre Beunardeau"
-excerpt: "Four CBP press releases, one port, one summer: 875 counterfeit Audemars Piguet watches in three Hong Kong parcels, then a $9.3 million shipment of Rolex- and Louis Vuitton-branded fakes from South Korea. We aggregate the record, check the arithmetic — including a $1.25 billion figure that contradicts itself — and draw the infrastructure conclusion: the border cannot be the trust layer."
-description: "CBP seized 1,027 suspected counterfeit watches across four Louisville shipments in summer 2026. What the releases prove and what borders cannot authenticate."
+title: 'Louisville Fake Watch Seizures: What the Figures Mean'
+date: '2026-08-27'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  Four 2026 CBP releases describe 1,027 counterfeit watches seized in
+  Louisville. Understand the valuation and the separate checks a resale buyer
+  needs.
+description: >-
+  Four 2026 CBP releases describe 1,027 counterfeit watches seized in
+  Louisville. Understand the valuation and the separate checks a resale buyer
+  needs.
 tags:
   - counterfeit
   - authentication
@@ -12,257 +18,68 @@ tags:
   - border-enforcement
   - traceability
 published: true
-coverImage: "/images/blog/cbp-louisville-fake-watches.jpg"
-coverImageAlt: "Macro view of a mechanical luxury watch movement dissolving into glowing cyan particles on a dark obsidian background"
+coverImage: /images/blog/cbp-louisville-fake-watches.jpg
+coverImageAlt: >-
+  Macro view of a mechanical luxury watch movement dissolving into glowing cyan
+  particles on a dark obsidian background
 faq:
-  - question: "How many counterfeit watches did CBP seize in Louisville in summer 2026?"
-    answer: "875 counterfeit Audemars Piguet across three shipments from Hong Kong, intercepted on June 18, July 9 and July 31, 2026. A fourth seizure on August 18 added 152 watches bearing suspected Rolex and Louis Vuitton trademarks, plus 32 pairs of suspected Gucci shoes, from South Korea. The stated hypothetical retail values now sum to over $134 million."
-  - question: "Is the $1.25 billion figure for the Louisville seizures accurate?"
-    answer: "It is unverified. The figure appears in CBP's August 7 release. But its own per-shipment values — $54 million, $28 million, $43 million — sum to $125 million, one tenth of the headline number. Local TV, including WLKY, amplified the larger figure. All amounts are hypothetical retail prices, not the value of the counterfeits."
-  - question: "Why are so many counterfeit watches seized at the Port of Louisville?"
-    answer: "CBP's releases do not explain the port's role, and we do not speculate. CBP does state that over 90% of counterfeit seizures occur in international mail and express environments, the small-parcel e-commerce channels. Louisville seizures have appeared in CBP communications since at least 2022."
-  - question: "Does seizing counterfeit watches at the border stop the trade?"
-    answer: "It removes individual shipments but does not establish how much traffic escapes detection. CBP describes targeting, examination and specialist authentication; the cited releases do not publish the denominator of parcels examined or a detection rate. A seizure also never proves a genuine watch genuine — which is what buyers, retailers and resale platforms actually need."
-  - question: "What does authentication verifiable at the source mean?"
-    answer: "Each genuine watch receives a unique digital identity at manufacture, issued by the maison itself. Anyone — a buyer, a retailer, a customs officer — can verify it in seconds without contacting the brand. A counterfeit may copy a dial or a serial number; it cannot produce a valid attestation from the maison. It can however relay one copied from a genuine watch — physical binding remains the open problem."
+  - question: Did the seized counterfeit watches cost $134.3 million?
+    answer: >-
+      No. The combined figure is a lower bound for CBP's estimated retail value
+      of equivalent genuine goods across the four shipments, including shoes in
+      the last one. It is not the price paid for the counterfeits or a measured
+      business loss.
+  - question: Does a product passport replace physical authentication?
+    answer: >-
+      No. A product record can supply evidence about an item, but its issuer,
+      current status and association with the physical object still need
+      checking. Physical examination and seller evidence remain separate.
 ---
+Four US Customs and Border Protection releases describe 1,027 counterfeit watches intercepted in Louisville during summer 2026. Their valuations refer to the estimated retail value of equivalent genuine goods, not the prices paid for the counterfeits or losses proved by the seizures.
 
-U.S. Customs and Border Protection reported 1,027 suspected counterfeit watches across four parcels intercepted at the Port of Louisville between June 18 and August 18, 2026. The first three shipments contained 875 Audemars Piguet-branded watches from Hong Kong; the fourth added 152 Rolex- and Louis Vuitton-branded watches plus 32 pairs of Gucci-branded shoes from South Korea. Read together, the releases document a concentrated summer cluster. Our conclusion — that interception cannot substitute for authentication at the source — is an infrastructure argument, not a CBP finding.
+The record is useful for a resale buyer because it shows why a familiar brand name, package or document cannot settle the identity of the item being offered.
 
-Each seizure made local headlines as a standalone item. Nobody aggregated the three. This article consolidates the releases into one record, checks their arithmetic, and asks what the pattern means for anyone who makes, sells or buys high-end watches.
+## Four shipments, with two different dates to keep straight
 
-*Update of 1 September 2026: CBP announced a fourth Louisville seizure on 26 August — 152 watches and 32 pairs of shoes, hypothetical MSRP over $9.3 million. It is integrated below; the series total moves from over $125 million to over $134 million.*
+CBP's publication date is not always the interception date:
 
-## The four seizures, in one record
+| CBP release | Interception | Goods reported | Genuine-equivalent retail estimate |
+| --- | --- | --- | --- |
+| [30 June 2026](https://www.cbp.gov/newsroom/national-media-release/shipment-worth-54-million-counterfeit-watches-seized-cbp-officers) | 18 June | 375 Audemars Piguet-branded watches | More than $54 million |
+| [17 July 2026](https://www.cbp.gov/newsroom/national-media-release/28-million-counterfeit-watches-seized-louisville-cbp) | 9 July | 200 Audemars Piguet-branded watches | More than $28 million |
+| [7 August 2026](https://www.cbp.gov/newsroom/national-media-release/43-million-counterfeit-watches-intercepted-louisville-cbp) | 31 July | 300 Audemars Piguet-branded watches | More than $43 million |
+| [26 August 2026](https://www.cbp.gov/newsroom/national-media-release/louisville-cbp-intercepts-9-million-shipment-counterfeit-watches) | 18 August | 152 Rolex- and Louis Vuitton-branded watches, plus 32 pairs of Gucci-branded shoes | More than $9.3 million |
 
-Every fact below comes from CBP's own newsroom. Each release is linked at the point of use.
+Adding those shipment figures gives **1,027 watches and 32 pairs of shoes**, with a combined genuine-equivalent estimate above **$134.3 million**. The final shipment's estimate includes the shoes, so it is not a watches-only valuation.
 
-**Seizure one.** On June 18, officers at the Port of Louisville pulled a parcel arriving from Hong Kong, bound for a residence in New York. Inside: 375 Audemars Piguet watches, later deemed inauthentic by CBP's Centers of Excellence and Expertise, the agency's trade experts. Had they been genuine, their combined retail price would have exceeded $54 million, per the [June 30 release](https://www.cbp.gov/newsroom/national-media-release/shipment-worth-54-million-counterfeit-watches-seized-cbp-officers).
+The 7 August release also contains a $1.25 billion aggregate that these individual figures do not allow us to reconcile. It is not used in the calculation above.
 
-**Seizure two.** On July 9, officers seized a second Hong Kong parcel, this one headed to Illinois. It held 200 watches bearing suspected Audemars Piguet trademarks. Their combined hypothetical retail value exceeded $28 million, per the [July 17 release](https://www.cbp.gov/newsroom/national-media-release/28-million-counterfeit-watches-seized-louisville-cbp).
+The seizures establish intercepted goods. They do not measure how many counterfeit items passed undetected or prove that border enforcement is generally ineffective.
 
-**Seizure three.** On July 31, a third Hong Kong shipment was intercepted, addressed to a residence in Houston. It concealed 300 Audemars Piguet watches, worth over $43 million at retail had they been real, per the [August 7 release](https://www.cbp.gov/newsroom/national-media-release/43-million-counterfeit-watches-intercepted-louisville-cbp).
+## A resale buyer faces a different decision
 
-The August 7 release does the aggregation itself, once: three shipments, 875 counterfeit Audemars Piguet watches, all from Hong Kong. Louisville Port Director Philip Onken framed the stakes in the first release. Intellectual property theft, he said, "threatens America's economic vitality and funds criminal activities and organized crime".
+Consider a fictional dealer receiving a watch with a box, a serial number and a digital certificate. None of those features alone establishes that the physical watch matches the certificate.
 
-**Seizure four — a different file.** On August 18, eleven days after that release, officers pulled a parcel arriving from South Korea, bound for Georgia. Inside: 152 watches bearing suspected Rolex and Louis Vuitton trademarks, and 32 pairs of shoes bearing the suspected Gucci trademark. Had the items been genuine, their combined retail price would have exceeded $9.3 million, per the [August 26 release](https://www.cbp.gov/newsroom/national-media-release/louisville-cbp-intercepts-9-million-shipment-counterfeit-watches). It does not double-count the August 7 aggregate: the parcel was intercepted after that release was published. Its profile differs too — mixed brands, a new origin, shoes alongside watches. The summer record now stands at 1,027 counterfeit watches and over $134 million in hypothetical MSRP.
+The dealer first needs a specialist assessment of the watch and its condition. It also needs seller and provenance evidence relevant to the proposed transaction. Provenance means the documented history of an object; it may include purchase documents, service records and other attributable evidence.
 
-The pattern is new in scale, not in place. In late 2025, the same port announced smaller, mixed-brand seizures. Officers reported [53 counterfeit watches worth $6.6 million in November](https://www.cbp.gov/newsroom/local-media-release/louisville-cbp-snags-parcels-6-million-counterfeit-watches). Two weeks later came [160 fake Rolex watches worth $2.57 million](https://www.cbp.gov/newsroom/local-media-release/25-million-counterfeit-rolex-watches-seized-cbp-officers-louisville). In December, the port announced [$18 million in assorted counterfeits](https://www.cbp.gov/newsroom/local-media-release/cbp-officers-intercept-18-million-counterfeits-louisville), including Cartier and Audemars Piguet items. Summer 2026 is different: one brand in three industrial-looking batches, then a fourth, mixed-brand parcel from a new origin.
+Audemars Piguet's [official service page](https://www.audemarspiguet.com/gb/en/services/all-services), consulted on 12 September 2026, distinguishes an archive extract from an authenticity certificate that requires examination of the watch. That distinction helps a buyer ask what a document actually establishes.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 300" role="img" aria-label="Timeline of counterfeit watch seizures announced by CBP at the Port of Louisville, 2022 to 2026, with an axis break between 2022 and late 2025. Marker size scales with the stated hypothetical retail value. April 12, 2022: 81 million dollars in fake watches over six months. November 3, 2025: 53 watches, 6.6 million dollars. November 20, 2025: 160 fake Rolex watches, 2.57 million dollars. December 10, 2025: 18 million dollars in mixed-brand counterfeits. Then the summer 2026 cluster, highlighted: June 18, 375 watches, over 54 million dollars; July 9, 200 watches, over 28 million dollars; July 31, 300 watches, over 43 million dollars; August 18, 152 watches and 32 pairs of shoes, over 9.3 million dollars, from South Korea." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="26" fontSize="14" fontWeight="600" fill="#FFFFFF">Port of Louisville — seizure escalation, 2022 to 2026</text>
-    <text x="20" y="44" fontSize="10" fill="rgba(255, 255, 255, 0.55)">Marker size scales with stated hypothetical MSRP · axis break between 2022 and late 2025</text>
-    <rect x="318" y="56" width="102" height="204" rx="6" fill="#00FFFF" opacity="0.06" />
-    <text x="369" y="72" textAnchor="middle" fontSize="9.5" fontWeight="600" fill="#22D3EE">Summer 2026</text>
-    <text x="369" y="84" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">1,027 watches · 4 seizures</text>
-    <line x1="24" y1="170" x2="416" y2="170" stroke="#062840" strokeWidth="1.5" />
-    <path d="M 82 162 L 90 178 M 90 162 L 98 178" stroke="#062840" strokeWidth="1.5" />
-    <circle cx="50" cy="170" r="11" fill="#0E7490" opacity="0.9" />
-    <line x1="50" y1="181" x2="50" y2="192" stroke="#062840" strokeWidth="1" />
-    <text x="50" y="206" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">12 Apr 2022</text>
-    <text x="50" y="220" textAnchor="middle" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">$81M over 6 months</text>
-    <circle cx="112" cy="170" r="4" fill="#0E7490" opacity="0.9" />
-    <line x1="112" y1="166" x2="112" y2="146" stroke="#062840" strokeWidth="1" />
-    <text x="112" y="126" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">3 Nov 2025</text>
-    <text x="112" y="140" textAnchor="middle" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">$6.6M · 53 watches</text>
-    <circle cx="130" cy="170" r="3" fill="#0E7490" opacity="0.9" />
-    <line x1="130" y1="173" x2="130" y2="192" stroke="#062840" strokeWidth="1" />
-    <text x="130" y="206" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">20 Nov 2025</text>
-    <text x="130" y="220" textAnchor="middle" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">$2.57M · 160 Rolex</text>
-    <circle cx="152" cy="170" r="5" fill="#0E7490" opacity="0.9" />
-    <line x1="152" y1="165" x2="152" y2="120" stroke="#062840" strokeWidth="1" />
-    <text x="152" y="100" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">10 Dec 2025</text>
-    <text x="152" y="114" textAnchor="middle" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">$18M · mixed brands</text>
-    <circle cx="330" cy="170" r="9" fill="#00FFFF" opacity="0.85" />
-    <line x1="330" y1="161" x2="330" y2="120" stroke="#062840" strokeWidth="1" />
-    <text x="330" y="100" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">18 Jun 2026</text>
-    <text x="330" y="114" textAnchor="middle" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">$54M · 375 watches</text>
-    <circle cx="352" cy="170" r="6" fill="#00FFFF" opacity="0.85" />
-    <line x1="352" y1="164" x2="352" y2="146" stroke="#062840" strokeWidth="1" />
-    <text x="352" y="126" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">9 Jul 2026</text>
-    <text x="352" y="140" textAnchor="middle" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">$28M · 200 watches</text>
-    <circle cx="376" cy="170" r="8" fill="#22D3EE" opacity="0.85" />
-    <line x1="376" y1="178" x2="376" y2="192" stroke="#062840" strokeWidth="1" />
-    <text x="390" y="206" textAnchor="end" fontSize="10" fontWeight="600" fill="#22D3EE">31 Jul 2026</text>
-    <text x="390" y="220" textAnchor="end" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">$43M · 300 watches</text>
-    <circle cx="402" cy="170" r="4" fill="#22D3EE" opacity="0.85" />
-    <line x1="402" y1="178" x2="402" y2="226" stroke="#062840" strokeWidth="1" />
-    <text x="414" y="240" textAnchor="end" fontSize="10" fontWeight="600" fill="#22D3EE">18 Aug 2026</text>
-    <text x="414" y="254" textAnchor="end" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">$9.3M · 152 + shoes</text>
-    <text x="20" y="280" fontSize="10" fill="rgba(255, 255, 255, 0.55)">Source: CBP newsroom releases, linked inline. All dollar figures are hypothetical MSRP.</text>
-    <text x="20" y="295" fontSize="10" fill="rgba(255, 255, 255, 0.55)">Summer 2026: three Hong Kong parcels — then a mixed-brand batch from South Korea.</text>
-  </svg>
-</div>
+## Where a digital record helps
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 350" role="img" aria-label="Bar chart of the four counterfeit goods seizures at the Port of Louisville in summer 2026. June 18: 375 watches, MSRP over 54 million dollars, bound for New York. July 9: 200 watches, MSRP over 28 million dollars, bound for Illinois. July 31: 300 watches, MSRP over 43 million dollars, bound for Houston. August 18: 152 watches and 32 pairs of shoes, MSRP over 9.3 million dollars, bound for Georgia, drawn as an outlined bar because it is a mixed-brand shipment from South Korea, distinct from the Audemars Piguet cluster. Arithmetic total from CBP's per-shipment figures: 1,027 watches and 32 pairs of shoes, over 134 million dollars. Unverified: the 1.25 billion dollar figure in CBP's August 7 release, which is ten times its own per-shipment math." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="26" fontSize="14" fontWeight="600" fill="#FFFFFF">Port of Louisville — the summer 2026 file</text>
-    <text x="68" y="58" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">Jun 18</text>
-    <rect x="78" y="46" width="200" height="14" rx="3" fill="#00FFFF" opacity="0.85" />
-    <text x="78" y="78" fontSize="11" fill="rgba(255, 255, 255, 0.7)">375 watches · MSRP &gt; $54M · to New York</text>
-    <text x="68" y="118" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">Jul 9</text>
-    <rect x="78" y="106" width="104" height="14" rx="3" fill="#22D3EE" opacity="0.85" />
-    <text x="78" y="138" fontSize="11" fill="rgba(255, 255, 255, 0.7)">200 watches · MSRP &gt; $28M · to Illinois</text>
-    <text x="68" y="178" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">Jul 31</text>
-    <rect x="78" y="166" width="159" height="14" rx="3" fill="#0E7490" opacity="0.9" />
-    <text x="78" y="198" fontSize="11" fill="rgba(255, 255, 255, 0.7)">300 watches · MSRP &gt; $43M · to Houston</text>
-    <text x="68" y="238" textAnchor="end" fontSize="11" fontWeight="600" fill="#22D3EE">Aug 18</text>
-    <rect x="78" y="226" width="34" height="14" rx="3" fill="none" stroke="#22D3EE" strokeWidth="1.2" strokeDasharray="4 3" opacity="0.9" />
-    <text x="78" y="258" fontSize="11" fill="rgba(255, 255, 255, 0.7)">152 watches + 32 pr shoes · MSRP &gt; $9.3M · to Georgia</text>
-    <text x="78" y="274" fontSize="9.5" fill="rgba(255, 255, 255, 0.5)">Outlined: mixed brands, from South Korea — distinct from the AP cluster</text>
-    <line x1="20" y1="292" x2="420" y2="292" stroke="#062840" strokeWidth="1" />
-    <text x="20" y="316" fontSize="11" fontWeight="600" fill="#FFFFFF">Arithmetic: 1,027 watches + 32 pairs of shoes · over $134M</text>
-    <text x="20" y="336" fontSize="11" fill="rgba(255, 255, 255, 0.55)">Unverified: "$1.25B" in the Aug 7 release — 10× its own math</text>
-  </svg>
-</div>
+A signed record can help a recipient check who issued a statement and whether the signed information was changed. Its usefulness still depends on the issuer, the statement's scope and its association with the item in front of the buyer.
 
-## The arithmetic problem: $125 million, not $1.25 billion
+The record may also have been replaced or withdrawn. Our [revocation guide](/blog/2026-09-05-product-passport-revocation-resale) explains why an apparently valid signature is not the end of the check.
 
-The August 7 release contains one figure that does not survive its own document. It states that the 875 watches, had they been real, would have carried a combined retail price of over $1.25 billion. But the release's own per-shipment figures are $54 million, $28 million and $43 million. They sum to $125 million — exactly one tenth of the headline number.
+A passport therefore supports the evidence trail. It cannot guarantee an object's authenticity in a few seconds or remove every future need for examination.
 
-Local television, including [WLKY](https://www.wlky.com/article/louisville-customs-cbp-counterfeit-watches-audemars-piguet/73382733), led with the billion-dollar figure. Trade aggregators repeated it. Nobody we found checked it against the release's own arithmetic.
+## Frequently asked questions
 
-We treat $125 million-plus as the defensible arithmetic total, because it is the sum of CBP's stated per-shipment figures. It remains a sum of hypothetical MSRP estimates, not a measured market value. The $1.25 billion line is reported but unverified — most likely a typo that travelled.
+### Did the seized counterfeit watches cost $134.3 million?
 
-With the fourth seizure, the series total moves to over $134 million — the same arithmetic, one release later. The $9.3 million shipment is mixed-brand and comes from South Korea; it does not change the AP cluster's own math.
+No. The combined figure is a lower bound for CBP's estimated retail value of equivalent genuine goods across the four shipments, including shoes in the last one. It is not the price paid for the counterfeits or a measured business loss.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 236" role="img" aria-label="Comparison diagram, bars to scale. Arithmetic from CBP's per-shipment figures: 54 plus 28 plus 43 million dollars equals over 125 million dollars, drawn as a short solid cyan bar. Reported but unverified: the 1.25 billion dollar headline in the same August 7 release, drawn as a dashed-outline bar exactly ten times longer. The 1.25 billion figure is ten times the release's own arithmetic and is treated as a likely typo, not a fact. All figures are hypothetical retail prices, not the value of the counterfeits." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="26" fontSize="14" fontWeight="600" fill="#FFFFFF">Arithmetic vs reported — a factor of ten</text>
-    <text x="20" y="44" fontSize="10" fill="rgba(255, 255, 255, 0.55)">Same August 7 release · hypothetical MSRP · bars to scale (10×)</text>
-    <text x="20" y="82" fontSize="11" fontWeight="600" fill="#22D3EE">Arithmetic — sum of three stated shipment figures</text>
-    <rect x="20" y="92" width="38" height="18" rx="3" fill="#00FFFF" opacity="0.85" />
-    <text x="66" y="105" fontSize="11" fill="#FFFFFF">$54M + $28M + $43M = over $125M</text>
-    <text x="20" y="144" fontSize="11" fontWeight="600" fill="rgba(255, 255, 255, 0.7)">Reported, unverified — the release's own headline</text>
-    <rect x="20" y="154" width="380" height="18" rx="3" fill="none" stroke="#22D3EE" strokeWidth="1.2" strokeDasharray="5 4" opacity="0.7" />
-    <text x="30" y="167" fontSize="11" fontWeight="600" fill="rgba(255, 255, 255, 0.85)">"$1.25B" — 10× its own per-shipment math</text>
-    <text x="20" y="198" fontSize="10" fill="rgba(255, 255, 255, 0.55)">We treat the billion-dollar line as a likely typo that travelled, not as a fact.</text>
-    <text x="20" y="216" fontSize="10" fill="rgba(255, 255, 255, 0.55)">Every dollar figure is a hypothetical retail price, not the value of the counterfeits.</text>
-  </svg>
-</div>
+### Does a product passport replace physical authentication?
 
-One more caution: every dollar figure here is a hypothetical retail price. It is what the watches would have cost new, had they been genuine. The implied per-watch price is stable across the three seizures, at roughly $140,000 to $144,000. That consistency suggests the trade experts valued the fakes against a genuine retail price list. It says nothing about what the counterfeits themselves would have sold for.
+No. A product record can supply evidence about an item, but its issuer, current status and association with the physical object still need checking. Physical examination and seller evidence remain separate.
 
-There is also a headline effect: the bigger the hypothetical retail value, the bigger the story appears. That does not establish anyone's motive, but it makes the qualifier essential. MSRP here is a counterfactual benchmark for genuine goods, not the transaction value of the seized items or the size of the counterfeit market.
-
-| Claim | Status | Basis |
-| --- | --- | --- |
-| 875 counterfeit Audemars Piguet watches seized | Confirmed | Stated in the Aug 7 release; matches the per-shipment counts (375 + 200 + 300) |
-| All three shipments from Hong Kong | Confirmed | Each of the three CBP releases |
-| Destinations: New York, Illinois, Houston | Confirmed | Each of the three CBP releases |
-| Combined MSRP over $125 million | Arithmetic from CBP figures | Sum of the per-shipment figures: $54M + $28M + $43M; hypothetical MSRP, not market value |
-| Fourth seizure: 152 watches, 32 pairs of shoes, over $9.3M | Confirmed | Aug 26 release; seized Aug 18, South Korea to Georgia |
-| Series total: 1,027 watches, over $134 million | Arithmetic from CBP figures | $54M + $28M + $43M + $9.3M across the four releases; fourth figure also includes 32 pairs of shoes |
-| Combined MSRP over $1.25 billion | Reported, unverified | Aug 7 release; contradicts its own figures; amplified by local TV |
-| Seized watches destroyed | Not established | Releases state CBP's authority to seize, forfeit and destroy; no per-case outcome is published |
-
-## What the coverage missed
-
-Coverage of the three seizures followed a familiar pattern. Local outlets reported each parcel as a colorful brief: a big number, a victimless-looking crime story, a quote from the port director. Trade aggregators picked up mostly the August release, usually with the unverified $1.25 billion figure attached. No outlet placed the releases side by side. Yet the aggregation is the story: one brand in three industrial-looking batches, then a fourth parcel from a new origin. Episodic framing makes each seizure look like an endpoint. Four parcels are not proof of a supply chain, but the pattern in the consolidated record is consistent with one.
-
-## Why the border cannot keep up
-
-None of what follows diminishes the officers' work. The seizures are real catches. The problem is structural.
-
-**The channel is the problem.** CBP itself states that [over 90% of all counterfeit seizures occur in the international mail and express environments](https://www.cbp.gov/newsroom/national-media-release/shipment-worth-54-million-counterfeit-watches-seized-cbp-officers). That is the small-parcel economy. The releases describe targeted examination and specialist authentication, but publish neither the number of parcels examined nor a detection rate. Four interceptions prove these parcels were detected; they say nothing about how many similar parcels passed.
-
-**The pattern looks industrial — that part is our inference.** Batches of 200 to 375 watches of a single brand suggest production-line volumes. The late-2025 Louisville seizures were smaller and mixed-brand. Summer 2026 is concentrated and repeated, not monotonically growing: the parcel counts are 375, 200, 300 and 152 watches. Four shipments do not prove an organisation.
-
-**Detection is expert labor.** Each catch follows the same chain: officer targeting, physical examination, then authentication by the Centers of Excellence and Expertise. Every step is skilled human time. The maisons themselves say as much: Audemars Piguet's [own services FAQ](https://www.audemarspiguet.com/us/en/services/faq) states that "the authenticity of an AP watch can only be confirmed after examining it in our workshops." The authenticator of last resort is still the maison's bench. Counterfeiters scale with machines; customs scales with headcount.
-
-**The deepest limit is conceptual.** A border seizure removes fake goods from circulation. It never proves a genuine watch genuine. Buyers, retailers and resale platforms have no border officer at hand when they need one. Enforcement protects brands in court. It does not protect a buyer at the moment of purchase.
-
-What happens after a seizure changes little for the market. CBP has authority to detain, seize, forfeit and ultimately destroy infringing goods. The August 7 release adds that consumers may be liable for a fine even without intent to import counterfeits. The fake watches leave circulation; the demand that ordered them does not. The buyer who wanted an Audemars Piguet at a fraction of retail still wants one.
-
-## What verifiable-at-the-source authentication changes
-
-For a watch maison, the Louisville file reframes the question. The choice is not between customs recordation and nothing. It is between relying on interception alone, or giving every genuine watch a proof that travels with it.
-
-CBP's [e-Recordation programme](https://iprr.cbp.gov/s/) already shows the logic. A brand records its trademarks with customs, and officers can then detain infringing goods. Recordation empowers the border. It does nothing for the secondary market.
-
-The regulatory wind blows the same way. The EU's Digital Product Passport framework, covered when [the registry and standards went live](/blog/2026-08-25-eu-dpp-registry-live), will make product-level data carriers mandatory category by category. LVMH has already put [its group-level DPP strategy in writing](/blog/2026-08-26-lvmh-dpp-strategy). No delegated act covers watches yet. But the direction is identical: authenticity data born with the product, not reconstructed at a checkpoint.
-
-Here is the checklist we would put in front of any watchmaker's executive committee.
-
-1. **Issuance at source**: does every watch receive a unique digital identity at manufacture, before it enters any distribution channel?
-2. **Universal verification**: can a buyer, a retailer or a customs officer check authenticity in seconds, without contacting the brand?
-3. **Independence**: does the proof still verify if the brand's servers are down — or if the brand is gone in thirty years?
-4. **Transfer**: does the proof change hands with the watch at resale, without a manual re-issue?
-5. **Service history**: can authorised service centres write each intervention to the record, without rewriting its history?
-6. **Privacy**: can a buyer verify a watch without exposing ownership data to the world?
-7. **Interoperability**: is the record readable by systems the maison does not control — resale platforms, insurers, customs tooling?
-8. **Unit economics**: is the per-watch cost low enough to cover the entire production, not only the top references?
-
-A counterfeit can copy a dial, a caseback, even a printed serial number. It cannot produce a valid cryptographic attestation issued by the maison at the bench — though it can relay one copied from a genuine watch, a limit we detail below. That asymmetry, properly bounded, is the core of the argument.
-
-## Applying the checklist: a bounded case
-
-Take an illustrative independent watchmaker: 8,000 pieces a year, three collections, 40% of sales through multi-brand retailers, an active secondary market. The situation is fictional; the trade-offs are the ones we see in real engagements.
-
-Today, this maison relies on trademark recordation and paper certificates. Applying the checklist, three changes follow. Every watch leaves the bench with a unique digital identity, issued by the maison itself. Retailers scan at intake, resale platforms verify before listing, and service centres write each intervention to the record. Customs recordation stays in place — as a backstop, not as the front line.
-
-Bounded conclusion: the Louisville file did not tell this maison to abandon border tools. It told it that border tools protect the brand's trademark, while buyers need proof they can check themselves.
-
-## The limits of what we know
-
-Intellectual honesty about the file. An analysis is only worth what its evidence supports.
-
-- **All dollar figures are hypothetical MSRP.** They describe what genuine watches would have cost. They are not the value of the counterfeits, nor a measure of anyone's revenue.
-- **The $1.25 billion figure is unverified.** It appears in CBP's August 7 release but contradicts the release's own per-shipment figures, which sum to $125 million. We report it as a likely error, not as a fact.
-- **The denominator is unknown.** Four seizures establish a pattern, not a rate. Nobody outside CBP knows how many similar parcels were not intercepted.
-- **No suspect, sender or recipient is named.** The releases give no indication of prosecutions, and we do not speculate.
-- **Why Louisville is not explained.** The releases do not say why this port recurs. CBP communications show Louisville seizures since at least 2022, including [$81 million in fake watches over six months](https://www.cbp.gov/newsroom/local-media-release/81-million-fake-watches-intercepted-louisville-cbp-6-months). We found no official explanation of the port's specific role.
-- **One brand dominates this file.** Whether Audemars Piguet is disproportionately targeted nationally is something these releases cannot tell us.
-- **A digital attestation does not make every fake verifiably fake.** It proves cryptographic integrity and issuer identity, not that the object in hand is the attested one. A copied QR code or a relayed NFC chip still verifies. Anti-cloning binding between identity and object remains an open engineering problem, and compromised or complicit issuance defeats every downstream check.
-
-## Galileo's take
-
-**Galileo's take: Louisville is what it looks like when enforcement works — and still cannot close the gap.** Four catches in a single summer is a good run for any port. It is also a demonstration that interception is retrospective, sampled and capacity-bound, while the supply it catches looks industrial and repeatable. The lesson for watchmakers is not to demand more officers. It is to stop asking the border to do a job that belongs at the bench.
-
-Honesty applies to our own thesis too. A digital attestation does not, by itself, make every fake verifiably fake. Authentication at the source has five distinct layers, and each one fails differently:
-
-1. **Attestation integrity.** Cryptography holds here: a counterfeiter cannot forge a valid signature from the maison. This layer is solved.
-2. **Issuer identity and authority.** Verification must prove the attestation comes from the maison itself, not from a lookalike issuer. Open identity standards handle this.
-3. **Physical binding.** Anti-cloning silicon exists: chips like NXP's [NTAG 424 DNA](https://www.nxp.com/products/rfid-nfc/nfc-hf/ntag-for-tags-and-labels/ntag-424-dna-424-dna-tagtamper-advanced-security-and-privacy-for-trusted-iot-applications:NTAG424DNA) authenticate dynamically at every read, on attack-resistant certified silicon. Our specifications anticipate NFC carrier types and an `nfc_bound` claim topic for chip-binding verification. The open problem is the durable link between the secure element and the watch itself: proving the genuine chip is still inside the object presented. Treat that binding as the problem the industry must engineer against, not as a solved feature.
-4. **Replay of a genuine identifier.** Short of cloning, a counterfeiter can copy a QR code or relay the NFC response of one authentic watch onto many fakes. The attestation verifies; the object in the buyer's hand is still counterfeit. Duplicate-scan analytics and event history help detect this. They do not prevent it.
-5. **Compromise or complicity at issuance.** If issuance keys leak, or an insider attests goods that never existed, every downstream check passes. Hardware key custody and audit trails mitigate this. Nothing eliminates it.
-
-What source-issued identity does change is the burden of proof. Today, a genuine watch cannot prove itself at the moment of purchase. A verifiable attestation born at the bench proves issuance and the integrity of the record — at customs, at retail, at resale, in thirty years. The watch itself proves genuine only where the physical binding of layer 3 is robust enough. Galileo Protocol exists to make that proof ordinary infrastructure. It is an open protocol: each physical item gets a verifiable digital twin, authenticity and service events become interoperable attestations, and personal data stays off-chain. Our schemas are published openly in our [specifications](/specifications), so a maison can pilot a full lifecycle — issue, authenticate, service, resell — without surrendering its data to anyone. Explore the [documentation](/docs) or [contact us](mailto:info@galileoprotocol.io) to discuss a pilot.
-
-## Sources
-
-- [CBP, A shipment worth $54 million of counterfeit watches seized by CBP officers in Louisville](https://www.cbp.gov/newsroom/national-media-release/shipment-worth-54-million-counterfeit-watches-seized-cbp-officers), 30 June 2026: 375 watches, Hong Kong to New York, MSRP over $54M; states that over 90% of all counterfeit seizures occur in the international mail and express environments. Consulted 27 August 2026.
-- [CBP, $28 million in counterfeit watches seized by Louisville CBP](https://www.cbp.gov/newsroom/national-media-release/28-million-counterfeit-watches-seized-louisville-cbp), 17 July 2026: 200 watches, Hong Kong to Illinois, MSRP over $28M. Consulted 27 August 2026.
-- [CBP, $43 million in counterfeit watches intercepted by Louisville CBP](https://www.cbp.gov/newsroom/national-media-release/43-million-counterfeit-watches-intercepted-louisville-cbp), 7 August 2026: 300 watches, Hong Kong to Houston, MSRP over $43M; cumulative 875 watches; contains the $1.25B figure that contradicts the per-shipment math. Consulted 27 August 2026.
-- [CBP, Louisville CBP intercepts a $9 million shipment of counterfeit watches](https://www.cbp.gov/newsroom/national-media-release/louisville-cbp-intercepts-9-million-shipment-counterfeit-watches), 26 August 2026: 152 watches bearing suspected Rolex and Louis Vuitton trademarks, 32 pairs of suspected Gucci shoes, seized August 18, from South Korea to Georgia, MSRP over $9.3M. Consulted 1 September 2026.
-- [CBP, Louisville CBP snags parcels with $6 million in counterfeit watches](https://www.cbp.gov/newsroom/local-media-release/louisville-cbp-snags-parcels-6-million-counterfeit-watches), 3 November 2025: 53 watches, retail $6.6M. Consulted 27 August 2026.
-- [CBP, $2.5 million in counterfeit Rolex watches seized by CBP officers in Louisville](https://www.cbp.gov/newsroom/local-media-release/25-million-counterfeit-rolex-watches-seized-cbp-officers-louisville), 20 November 2025: 160 watches from Taiwan, $2.57M. Consulted 27 August 2026.
-- [CBP, CBP officers intercept $18 million in counterfeits in Louisville](https://www.cbp.gov/newsroom/local-media-release/cbp-officers-intercept-18-million-counterfeits-louisville), 10 December 2025: mixed brands including Cartier, Audemars Piguet and Rolex. Consulted 27 August 2026.
-- [CBP, $81 Million in Fake Watches Intercepted by Louisville CBP in 6 Months](https://www.cbp.gov/newsroom/local-media-release/81-million-fake-watches-intercepted-louisville-cbp-6-months), 12 April 2022: historical recurrence context. Consulted 27 August 2026.
-- [WLKY, Louisville CBP seizes more than $1.25B in fake luxury watches over two-month period](https://www.wlky.com/article/louisville-customs-cbp-counterfeit-watches-audemars-piguet/73382733), 8 August 2026: local TV amplification of the unverified $1.25B figure. Consulted 27 August 2026.
-- [CBP e-Recordation programme](https://iprr.cbp.gov/s/): trademark recordation enabling border detention of infringing goods. Consulted 27 August 2026.
-- [NXP, NTAG 424 DNA — advanced security and privacy for trusted IoT applications](https://www.nxp.com/products/rfid-nfc/nfc-hf/ntag-for-tags-and-labels/ntag-424-dna-424-dna-tagtamper-advanced-security-and-privacy-for-trusted-iot-applications:NTAG424DNA): AES-128 Secure Unique NFC authentication on each read-out, attack-resistant certified silicon. Consulted 27 August 2026.
-- [Audemars Piguet, Services FAQ](https://www.audemarspiguet.com/us/en/services/faq): the maison states that the authenticity of an AP watch can only be confirmed after examining it in its workshops. Consulted 27 August 2026.
-
-## FAQ
-
-### How many counterfeit watches did CBP seize in Louisville in summer 2026?
-
-875 counterfeit Audemars Piguet across three shipments from Hong Kong, intercepted on June 18, July 9 and July 31, 2026. The total comes from CBP's [August 7 release](https://www.cbp.gov/newsroom/national-media-release/43-million-counterfeit-watches-intercepted-louisville-cbp) and matches the per-shipment counts in the June 30 and July 17 releases. A fourth seizure on August 18 added 152 watches bearing suspected Rolex and Louis Vuitton trademarks, plus 32 pairs of suspected Gucci shoes. The parcel came from South Korea, per the [August 26 release](https://www.cbp.gov/newsroom/national-media-release/louisville-cbp-intercepts-9-million-shipment-counterfeit-watches). The stated hypothetical retail values now sum to over $134 million.
-
-### Is the $1.25 billion figure for the Louisville seizures accurate?
-
-It is unverified. The figure appears in CBP's August 7 release. But its own per-shipment values — $54 million, $28 million, $43 million — sum to $125 million, one tenth of the headline number. Local TV, including [WLKY](https://www.wlky.com/article/louisville-customs-cbp-counterfeit-watches-audemars-piguet/73382733), amplified the larger figure. All amounts are hypothetical retail prices, not the value of the counterfeits.
-
-### Why are so many counterfeit watches seized at the Port of Louisville?
-
-CBP's releases do not explain the port's role, and we do not speculate. CBP does state that [over 90% of all counterfeit seizures occur in the international mail and express environments](https://www.cbp.gov/newsroom/national-media-release/shipment-worth-54-million-counterfeit-watches-seized-cbp-officers), the small-parcel e-commerce channels. Louisville seizures have appeared in CBP communications since at least 2022.
-
-### Does seizing counterfeit watches at the border stop the trade?
-
-It removes individual shipments but does not establish how much traffic escapes detection. CBP describes targeting, examination and specialist authentication; the cited releases do not publish the denominator of parcels examined or a detection rate. A seizure also never proves a genuine watch genuine — which is what buyers, retailers and resale platforms actually need.
-
-### What does authentication verifiable at the source mean?
-
-Each genuine watch receives a unique digital identity at manufacture, issued by the maison itself. Anyone — a buyer, a retailer, a customs officer — can verify it in seconds without contacting the brand. A counterfeit may copy a dial or a serial number; it cannot produce a valid attestation from the maison. It can however relay one copied from a genuine watch — physical binding remains the open problem.
+For the product-record architecture behind that trail, see the [Galileo documentation](/docs).

--- a/website/content/blog/2026-08-28-tods-gommino-two-passports-renoon-aura.mdx
+++ b/website/content/blog/2026-08-28-tods-gommino-two-passports-renoon-aura.mdx
@@ -1,10 +1,14 @@
 ---
-title: "Tod's Gommino: Two Passport Stacks, One Source of Truth?"
-date: "2026-08-28"
-modified: "2026-08-28"
-author: "Pierre Beunardeau"
-excerpt: "WWD reports Tod's new Digital Product Passport with Renoon. It is not the maison's first: Aura Blockchain Consortium and Temera NFC passports have shipped since November 2023, on the My Gommino since March 2025. One product line now carries two passport stacks — NFC for authenticity, QR for sustainability data. When the customer scans, which attestation wins?"
-description: "Tod's now runs two digital passports on its Gommino line: Aura NFC for authenticity, Renoon QR for sustainability data. Which one wins the scan?"
+title: 'Tod''s Digital Passports: From Product Page to Ownership'
+date: '2026-08-28'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  Tod's adds an online passport with Renoon alongside its Aura history. Follow
+  the announced customer journey and the limits of a scan as proof.
+description: >-
+  Tod's adds an online passport with Renoon alongside its Aura history. Follow
+  the announced customer journey and the limits of a scan as proof.
 tags:
   - dpp
   - espr
@@ -12,188 +16,70 @@ tags:
   - luxury
   - traceability
 published: true
-coverImage: "/images/blog/tods-gommino-two-passports-renoon-aura.jpg"
-coverImageAlt: "A handcrafted leather driving loafer on a craftsman's workbench beside a smartphone with a glowing cyan screen, in a dim luxury atelier"
+coverImage: /images/blog/tods-gommino-two-passports-renoon-aura.jpg
+coverImageAlt: >-
+  A handcrafted leather driving loafer on a craftsman's workbench beside a
+  smartphone with a glowing cyan screen, in a dim luxury atelier
 faq:
-  - question: "Is the Renoon passport Tod's first Digital Product Passport?"
-    answer: "No. Tod's has shipped Digital Product Passports with the Aura Blockchain Consortium since 20 November 2023, starting with the custom Di Bag. The maison extended the same NFC-based Tod's Passport to the My Gommino collection on 14 March 2025, with traceability by Temera. The Renoon partnership announced on 28 August 2026 adds a second, QR-based data layer."
-  - question: "What is the difference between Tod's NFC passport and the new QR passport?"
-    answer: "They carry different claim sets. The NFC passport, built with Aura and Temera, certifies authenticity and ownership: a secure digital certificate stored on the Aura Private Blockchain, product registration and premium services. The QR passport, built with Renoon, publishes materials, production processes, locations and company certifications — the sustainability and compliance data layer."
-  - question: "Which passport is the source of truth when a customer scans?"
-    answer: "Today, each programme vouches only for its own claims. The NFC chip answers 'is this pair genuine and who owns it'; the QR code answers 'what is it made of and how was it produced'. No public documentation describes a reconciliation layer between the two data layers. WWD reports that Renoon's data will be ensured through the Aura Blockchain Consortium, which suggests a shared integrity anchor — but the architecture is not public."
-  - question: "Does EU regulation require two passports on one product?"
-    answer: "No. Under the ESPR (Regulation (EU) 2024/1781, Articles 9 to 13), each product gets one Digital Product Passport, connected to a persistent unique product identifier. The number of carriers is not fixed: Article 9(2)(b) lets each product group's delegated act define 'one or more data carriers' — QR code, NFC tag, or both. For footwear, no delegated act has been adopted yet; according to Renoon's footwear DPP page, the European Commission's preparatory study is planned for the end of 2027. Tod's is moving ahead of the mandate — and previewing the interoperability problem every maison will face."
-  - question: "Can a QR code prove a shoe is authentic?"
-    answer: "No. A QR code is a printed, copyable carrier: it links to data, but anyone can photograph and reproduce it. Authenticity requires a cryptographic check that a copy cannot pass — typically a dynamic NFC authentication. Even then, proving the genuine chip is still inside the genuine shoe, the physical-binding problem, remains open engineering work."
+  - question: When did Renoon say the online Tod's passport would be available?
+    answer: >-
+      Renoon's 28 August 2026 announcement specified availability from 1
+      September. It also described the role of Aura's existing infrastructure.
+  - question: Does European law require exactly one passport for each item?
+    answer: >-
+      The ESPR framework does not impose that simple rule. Product rules
+      determine granularity, and article 11(d) addresses a new passport being
+      linked to the original passport or passports.
+  - question: Does scanning the shoe's NFC tag establish who legally owns it?
+    answer: >-
+      Not by itself. A scan can retrieve information or support a technical
+      check. The meaning of an ownership record depends on its issuer, terms and
+      relationship to the physical item and transaction.
 ---
+Tod's online Digital Product Passport with Renoon adds a way to consult product information before purchase. It should be read alongside the brand's earlier Aura programme, rather than assumed to be a competing proof system for the same pair of shoes.
 
-Tod's did not launch its first Digital Product Passport this week — it announced a second passport programme. [WWD reported on 28 August 2026](https://wwd.com/footwear-news/shoe-industry-news/tods-digital-product-passport-launch-1239125385/) that the maison is rolling out QR-based passports with Renoon on its signature Gommino loafers. The same product line has carried Aura Blockchain Consortium NFC passports on the My Gommino collection since March 2025.
+[Renoon's announcement of 28 August 2026](https://www.renoon.com/blog/tods-takes-its-digital-product-passport-online-with-renoon) specified availability from **1 September** and described the role of Aura's existing infrastructure. This source clarifies the online journey; it does not expose every technical step linking records to an individual pair.
 
-Two passport programmes, two Gommino sub-ranges, two carriers, two data layers — documented. Whether a single pair will ever carry both carriers is not. If, or when, it does, which attestation becomes the source of truth? That question is no longer theoretical. It is the exact interoperability problem the EU's Digital Product Passport framework will put in front of every maison — and Tod's just became its most concrete public case.
+## The earlier passport programme
 
-## What WWD reported on 28 August 2026
+[Aura announced Tod's participation on 20 November 2023](https://auraconsortium.com/news/tods-joins-aura-blockchain). Its [14 March 2025 My Gommino announcement](https://auraconsortium.com/news/tods-digital-product-passports-to-its-iconic-my-gommino-collection) described extending passports to the collection, including a Temera NFC tag in the right sole and a digital ownership-certificate journey.
 
-The WWD piece, dated 28 August 2026, announces that Tod's is launching Digital Product Passports on its website with Renoon, a compliance-focused provider. The rollout starts with the signature loafers and will extend to other products. The passports publish materials, production processes, locations and company certifications, delivered through QR codes.
+NFC is the short-range technology that allows a compatible phone to read a tag. These announcements are the partners' descriptions of the service. They do not establish that every NFC tag uses a particular anti-copying mechanism, or that a scan independently proves legal ownership.
 
-Renoon's role, per the article, is data plumbing. The company "structures and confirms consistency of product and supply chain data across both Tod's internal systems and those of its partners". Renoon CEO Iris Skrami frames the work as deep infrastructure: most companies have the data somewhere, but fragmented and unstructured.
+The Renoon announcement describes another point of access: information on the online product page before purchase. The existing Aura infrastructure remains part of the described arrangement.
 
-Two details matter for what follows. First, WWD states that the data in Tod's DPPs "will be ensured through the Aura Blockchain Consortium, which the brand joined in 2023". Second, Tod's general brand manager Carlo Alberto Beretta presents the passport as bringing "verified product information directly into the customer experience". Verified by whom, and against which registry, is precisely the open question.
+## What changes for the customer
 
-One caution on framing: the WWD headline travel wires, and some aggregator pickups, call this Tod's "first" Digital Product Passport. It is not, and the record below is unambiguous.
+A prospective buyer may want to understand materials and care before ordering. An owner later needs information about the item received, perhaps for a service request or resale.
 
-## The passport the Gommino already had
+Those are related uses, but they do not ask the same question. A product page can describe a model without identifying one physical pair. A record reached from a tag may be more specific, but the recipient still needs to know who issued it and what it claims.
 
-Tod's passport history is documented by the Aura Blockchain Consortium itself.
+The public announcements do not provide enough detail to independently reconstruct how every online and tagged record is reconciled for the same pair. That is a useful question for the provider, not evidence that the systems necessarily conflict.
 
-**20 November 2023.** Tod's [joins the Aura Blockchain Consortium](https://auraconsortium.com/news/tods-joins-aura-blockchain) and ships its first DPP on the custom Di Bag. Each bag is linked to what Aura calls an immutable traceability token. The passport carries product certificates, origin and craftsmanship data, and ownership certificates.
+## Linked records can be legitimate
 
-**14 March 2025.** Tod's [extends the Tod's Passport to the My Gommino collection](https://www.auraconsortium.com/news/tods-digital-product-passports-to-its-iconic-my-gommino-collection), with Aura and its ecosystem partner Temera. Each pair embeds an NFC chip in the right sole. Scanning it lets the customer register the product, claim official ownership, and access a secure digital certificate of authenticity stored on the Aura Private Blockchain. A wallet card, linked to the Tod's CRM, extends the experience in store. Aura's CEO Romain Carrere celebrated the milestone at the time, [telling The Modems in March 2025](https://themodems.com/fashion/tods-product-passports-my-gommino-loafers/) that "transparency, authenticity, and customer experience can go hand in hand".
+The [ESPR framework, article 11(d)](https://eur-lex.europa.eu/eli/reg/2024/1781/2024-06-28/eng), expressly addresses new passports being linked to the original passport or passports. It does not reduce every architecture to exactly one file per physical object. Product-specific rules determine whether information applies at model, batch or item level.
 
-The maison's [own DPP page](https://www.tods.com/us-en/Tods-Digital-Passport/) confirms the architecture as it stands: Aura blockchain technology plus the NFC tag. It covers the Di Bag and the My Gommino, with materials origin, production-chain locations and premium benefits such as extended warranty.
+For a fictional footwear company, the practical aim would be consistency across those levels. If care instructions change, a customer should not receive contradictory guidance depending on which code they scan. If an individual item is repaired, its service record should not accidentally describe every item in the model.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 240" role="img" aria-label="Timeline of Tod's Digital Product Passport history from 2023 to 2026. 20 November 2023: Tod's joins the Aura Blockchain Consortium and ships NFC passports on the custom Di Bag, built with Aura. 14 March 2025: the Tod's Passport extends to the My Gommino collection, NFC chip in the right sole, certificate of authenticity on the Aura Private Blockchain, traceability by Temera. 28 August 2026: Tod's adds a second passport layer with Renoon, QR codes publishing materials, production and sustainability data on the signature loafers — the two stacks now overlap on the same product line." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="26" fontSize="14" fontWeight="600" fill="#FFFFFF">Tod's passport history — one maison, two stacks</text>
-    <text x="20" y="44" fontSize="10" fill="rgba(255, 255, 255, 0.55)">Aura/Temera NFC since 2023 · Renoon QR added 28 Aug 2026</text>
-    <line x1="24" y1="130" x2="416" y2="130" stroke="#062840" strokeWidth="1.5" />
-    <circle cx="70" cy="130" r="8" fill="#0E7490" opacity="0.9" />
-    <line x1="70" y1="122" x2="70" y2="92" stroke="#062840" strokeWidth="1" />
-    <text x="70" y="72" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">20 Nov 2023</text>
-    <text x="70" y="86" textAnchor="middle" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">Di Bag · Aura · NFC</text>
-    <circle cx="230" cy="130" r="8" fill="#00FFFF" opacity="0.85" />
-    <line x1="230" y1="138" x2="230" y2="168" stroke="#062840" strokeWidth="1" />
-    <text x="230" y="186" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">14 Mar 2025</text>
-    <text x="230" y="200" textAnchor="middle" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">My Gommino · Aura + Temera · NFC</text>
-    <circle cx="368" cy="130" r="9" fill="#22D3EE" opacity="0.9" />
-    <line x1="368" y1="121" x2="368" y2="92" stroke="#062840" strokeWidth="1" />
-    <text x="368" y="72" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">28 Aug 2026</text>
-    <text x="368" y="86" textAnchor="middle" fontSize="9.5" fill="rgba(255, 255, 255, 0.7)">Loafers · Renoon · QR</text>
-    <rect x="160" y="104" width="256" height="52" rx="6" fill="none" stroke="#22D3EE" strokeWidth="1" strokeDasharray="5 4" opacity="0.6" />
-    <text x="288" y="118" textAnchor="middle" fontSize="8.5" fill="rgba(255, 255, 255, 0.6)">Same product line, two live stacks</text>
-    <text x="20" y="228" fontSize="9.5" fill="rgba(255, 255, 255, 0.55)">Source: Aura Blockchain Consortium (2023, 2025), WWD (2026), linked inline.</text>
-  </svg>
-</div>
+That requires clear identifiers and update responsibilities. Adding another QR code without agreeing those responsibilities would leave the underlying question unresolved.
 
-So the Renoon announcement is not an entry into product passports. It is the arrival of a second stack on a product line that already had one.
+## Ask for the complete journey
 
-## What Renoon adds — and what it does not
+Have the provider show one product from online research to purchase and a later service request. Establish which record each screen uses, who may update it and how the next recipient checks it. Do not assume that a digital ownership label substitutes for the transaction documents.
 
-The two stacks are not redundant. They answer different questions.
+## Frequently asked questions
 
-The NFC layer is an authenticity and ownership instrument. Its core attestation is a certificate of authenticity on the Aura Private Blockchain, bound to a chip embedded in the shoe. Its job is to answer: is this pair genuine, and who does it belong to?
+### When did Renoon say the online Tod's passport would be available?
 
-The QR layer is a compliance and transparency instrument. Per WWD, it publishes materials, production processes, locations and certifications — the data categories the ESPR will progressively mandate. Renoon's own [footwear DPP page](https://www.renoon.com/digital-product-passport-footwear) describes the typical carrier mix. QR codes serve as the primary carrier, GS1 Digital Link connects product and record, and NFC covers "selected authentication or premium product experiences".
+Renoon's 28 August 2026 announcement specified availability from 1 September. It also described the role of Aura's existing infrastructure.
 
-Renoon is not a newcomer pitching a pilot. Its [homepage](https://www.renoon.com) claims more than 30 live case studies and over 10 million passport-ready products. What its site does not publish today is any documentation of the Tod's integration itself. We checked its full public sitemap and found no Tod's case study or announcement. The deal is documented only by WWD's reporting.
+### Does European law require exactly one passport for each item?
 
-## One product line, two passports: who is the source of truth?
+The ESPR framework does not impose that simple rule. Product rules determine granularity, and article 11(d) addresses a new passport being linked to the original passport or passports.
 
-Here is the scan a customer may soon perform on the Gommino line. They tap the NFC chip in the right sole and land on the Tod's Passport: authenticity certificate, ownership, warranty, CRM-linked services. Or they scan a QR code and land on the Renoon-powered page: materials, production locations, certifications. Two entry points, two backends, two operators — Temera and Aura on one side, Renoon on the other. One caveat before drawing conclusions: the NFC passport ships on the custom My Gommino, and WWD describes the QR rollout as starting with signature loafers. Whether the same pair will ever carry both carriers is not documented; the scenario that follows is what happens if, or when, it does.
+### Does scanning the shoe's NFC tag establish who legally owns it?
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 300" role="img" aria-label="Diagram of the two-stack scan flow on the Gommino product line. The customer may one day scan one pair in two ways. The NFC chip in the right sole, operated with Temera, opens the Tod's Passport on the Aura Private Blockchain: certificate of authenticity, ownership claim, warranty and client services — it answers the question, is this pair genuine. The QR code, powered by Renoon, opens a page of materials, production locations and certifications — it answers the question, how was this pair made. WWD reports Renoon's data will be ensured through the Aura Blockchain Consortium, drawn as a dashed link between the two data layers. No public documentation describes a reconciliation layer deciding which attestation wins if the two ever disagree." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="26" fontSize="14" fontWeight="600" fill="#FFFFFF">One line, two scans — which layer answers?</text>
-    <rect x="128" y="44" width="184" height="34" rx="6" fill="#00FFFF" opacity="0.12" />
-    <text x="220" y="65" textAnchor="middle" fontSize="11" fontWeight="600" fill="#FFFFFF">Customer scans the Gommino</text>
-    <line x1="176" y1="78" x2="94" y2="106" stroke="#062840" strokeWidth="1.5" />
-    <line x1="264" y1="78" x2="346" y2="106" stroke="#062840" strokeWidth="1.5" />
-    <rect x="24" y="106" width="150" height="30" rx="6" fill="#0E7490" opacity="0.5" />
-    <text x="99" y="125" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#FFFFFF">NFC chip, right sole</text>
-    <rect x="266" y="106" width="150" height="30" rx="6" fill="#0E7490" opacity="0.5" />
-    <text x="341" y="125" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#FFFFFF">QR code</text>
-    <text x="99" y="150" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.6)">Aura + Temera</text>
-    <text x="341" y="150" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.6)">Renoon</text>
-    <line x1="99" y1="156" x2="99" y2="176" stroke="#062840" strokeWidth="1.5" />
-    <line x1="341" y1="156" x2="341" y2="176" stroke="#062840" strokeWidth="1.5" />
-    <rect x="24" y="176" width="150" height="64" rx="6" fill="#00FFFF" opacity="0.1" />
-    <text x="99" y="194" textAnchor="middle" fontSize="9.5" fontWeight="600" fill="#22D3EE">Aura Private Blockchain</text>
-    <text x="99" y="208" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Authenticity certificate</text>
-    <text x="99" y="220" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Ownership · warranty · CRM</text>
-    <text x="99" y="233" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">"Is this pair genuine?"</text>
-    <rect x="266" y="176" width="150" height="64" rx="6" fill="#00FFFF" opacity="0.1" />
-    <text x="341" y="194" textAnchor="middle" fontSize="9.5" fontWeight="600" fill="#22D3EE">Renoon data layer</text>
-    <text x="341" y="208" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Materials · production sites</text>
-    <text x="341" y="220" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Certifications</text>
-    <text x="341" y="233" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">"How was this pair made?"</text>
-    <line x1="174" y1="208" x2="266" y2="208" stroke="#22D3EE" strokeWidth="1" strokeDasharray="4 3" opacity="0.6" />
-    <text x="220" y="256" textAnchor="middle" fontSize="8.5" fill="rgba(255, 255, 255, 0.6)">Dashed link: Renoon data "ensured through Aura" (WWD)</text>
-    <text x="20" y="274" fontSize="9.5" fill="rgba(255, 255, 255, 0.55)">Undocumented: any reconciliation layer if the two attestations ever disagree.</text>
-    <text x="20" y="291" fontSize="9.5" fill="rgba(255, 255, 255, 0.55)">Sources: tods.com, auraconsortium.com, WWD 28 Aug 2026.</text>
-  </svg>
-</div>
+Not by itself. A scan can retrieve information or support a technical check. The meaning of an ownership record depends on its issuer, terms and relationship to the physical item and transaction.
 
-In the benign case, nothing conflicts. The NFC certificate says the pair is genuine; the QR page describes how it was made. The customer never notices the seam.
-
-But seams become visible exactly when it matters. Three scenarios:
-
-1. **Disagreement.** The sustainability layer states a material origin that the authenticity layer's production record does not corroborate. Which record does a regulator, a reseller or a court treat as authoritative?
-2. **Divergent lifecycle events.** The QR passport lists a repair; the NFC certificate knows nothing of it. At resale, the buyer reads two partial histories of one object.
-3. **Operator risk.** One vendor sunsets its platform, or the maison switches providers. Which half of the product's memory survives the migration?
-
-WWD's line about Renoon data being "ensured through" Aura hints at a shared integrity anchor. If accurate, Aura's chain would anchor both claim sets — a sensible architecture. But no public documentation confirms how the anchor works, who writes to it, or which attestation prevails in a conflict.
-
-| Question | NFC stack (Aura + Temera) | QR stack (Renoon) |
-| --- | --- | --- |
-| Primary claim | Authenticity, ownership | Materials, production, certifications |
-| Carrier | NFC chip in the right sole | QR code |
-| Backend | Aura Private Blockchain | Renoon data platform |
-| Copy-resistant carrier | Typically, dynamic chip authentication | No, printed and photographable |
-| Regulatory driver | Anti-counterfeiting, customer engagement | ESPR compliance preparation |
-| Documented since | Nov 2023 (Di Bag), Mar 2025 (My Gommino) | Aug 2026 (WWD only) |
-
-## Why the ESPR registry will not tolerate ambiguity
-
-Tod's is moving early. Renoon's own [footwear page](https://www.renoon.com/digital-product-passport-footwear) notes that no footwear-specific DPP delegated act exists yet, and the Commission's preparatory study is planned for the end of 2027. Nothing forced this launch except strategy.
-
-But the direction is set. When [the EU DPP registry and standards went live](/blog/2026-08-25-eu-dpp-registry-live), the passport stopped being a brand experience. It became market infrastructure: one product, one passport, resolvable by systems the brand does not control. And as we noted when reading [LVMH's group-level DPP strategy](/blog/2026-08-26-lvmh-dpp-strategy), the majors are consolidating their passport estates precisely because fragmentation does not scale.
-
-The [ESPR](https://eur-lex.europa.eu/eli/reg/2024/1781/oj) logic assumes one coherent passport per product, at model, batch or item level as set by each product group's delegated act. A maison running two stacks with two operators and two carriers will face a question its marketing never had to answer. Which attestation is authoritative for which claim? And how does a third party verify the linkage between them, in a machine-readable way? That is an interoperability contract, not a storytelling choice. Tod's is simply the first maison where the question is visible from the outside, because both of its stacks are.
-
-## The limits of what we know
-
-Intellectual honesty about this file.
-
-- **The Renoon integration is documented only by WWD.** Renoon's public site, checked today, documents neither the deal nor the Tod's data model. Tod's own DPP page still describes only the Aura/NFC architecture at the time of writing. Tod's Group's newsroom could not be consulted directly (access restrictions); the 2023 and 2025 history is corroborated by Aura's own releases.
-- **The QR passport's actual content is not public.** We have not seen a live Renoon-powered Tod's passport. The data categories above come from WWD's description, not from the product.
-- **The "ensured through Aura" mechanism is unverified.** WWD states it; no primary source we could consult today explains the technical linkage between Renoon's data and Aura's chain.
-- **We do not know whether the two carriers will coexist on the same pairs.** The rollout may target different SKUs, regions or sales channels. WWD says the rollout begins with signature loafers and will extend.
-- **A passport stack does not solve physical binding.** As detailed in our [analysis of the Louisville counterfeit seizures](/blog/2026-08-27-cbp-louisville-fake-watches-border-enforcement), a QR code can be photographed and a genuine NFC response can be relayed onto a fake. Two stacks double the attestations; they do not double the proof that the object in hand is the attested one.
-
-## Galileo's take
-
-**Galileo's take: the Tod's file is the interoperability question, dated.** One maison, one product line, two passport stacks — each legitimate, each answering a different question, neither publicly reconciled with the other. This is not a criticism of Tod's, which is ahead of the regulatory curve and transparent about its suppliers. It is a preview of what every maison will manage as ESPR enforcement approaches. Authenticity attestations born from anti-counterfeiting, sustainability attestations born from compliance — and a customer, soon a registry, expecting one coherent answer.
-
-The fix is not picking a winner between NFC and QR, or between consortium chains and compliance platforms. Carriers are a UX choice; registries are a trust choice. The fix is a layer where attestations verify independently of the operator that issued them. On an open protocol, authenticity claims, materials claims and lifecycle events about the same item resolve to one verifiable identity. That identity stays readable by systems the maison does not control — resale platforms, customs tooling, the EU registry itself. That is the layer Galileo Protocol builds: item-level digital twins, interoperable attestations, personal data off-chain, schemas published openly in our [specifications](/specifications). A maison should be able to run Aura for certificates and Renoon for sustainability data — and still present one coherent, verifiable product identity to the world. Explore the [documentation](/docs) or [contact us](mailto:info@galileoprotocol.io) to discuss what that reconciliation layer looks like for your maison.
-
-## Sources
-
-- [WWD, Tod's Launches Digital Product Passports With Renoon](https://wwd.com/footwear-news/shoe-industry-news/tods-digital-product-passport-launch-1239125385/), 28 August 2026: Renoon partnership, QR carriers, loafers first, Skrami and Beretta quotes, data "ensured through the Aura Blockchain Consortium". Consulted 28 August 2026.
-- [Aura Blockchain Consortium, Tod's joins Aura Blockchain Consortium, Securing Digital Product Passports for their Iconic custom Di Bag](https://auraconsortium.com/news/tods-joins-aura-blockchain), 20 November 2023: first Tod's DPP, Di Bag, traceability token, ownership certificates. Consulted 28 August 2026.
-- [Aura Blockchain Consortium, Tod's Digital Product Passports to its Iconic My Gommino Collection](https://www.auraconsortium.com/news/tods-digital-product-passports-to-its-iconic-my-gommino-collection), 14 March 2025: NFC chip in the right sole, Temera traceability, certificate of authenticity on the Aura Private Blockchain, wallet card linked to Tod's CRM. Consulted 28 August 2026.
-- [Tod's, Digital Product Passport page](https://www.tods.com/us-en/Tods-Digital-Passport/): current Aura/NFC architecture for Di Bag and My Gommino, materials origin, production-chain locations, premium benefits. Consulted 28 August 2026.
-- [Renoon, homepage](https://www.renoon.com): DPP compliance positioning, 30+ live case studies, over 10 million passport-ready products. Consulted 28 August 2026.
-- [Renoon, Digital Product Passport for footwear](https://www.renoon.com/digital-product-passport-footwear): no footwear delegated act adopted, Commission preparatory study planned end 2027, QR and GS1 Digital Link as typical carriers, NFC for authentication experiences. Consulted 28 August 2026.
-- [The Modems, Tod's Goes Digital: Blockchain-Powered Product Passports for My Gommino Loafers](https://themodems.com/fashion/tods-product-passports-my-gommino-loafers/), March 2025: Romain Carrere quote on the My Gommino extension, NFC chip by Temera on Aura's private blockchain. Consulted 28 August 2026.
-- [Regulation (EU) 2024/1781 (ESPR), EUR-Lex](https://eur-lex.europa.eu/eli/reg/2024/1781/oj), 13 June 2024: Chapter III, Articles 9 to 13 — Digital Product Passport, requirements, technical design, unique identifiers and registry; one passport connected through a data carrier to a persistent unique product identifier (Article 10(1)(a)), with each product group's delegated act defining "one or more data carriers" (Article 9(2)(b)). Consulted 28 August 2026.
-
-## FAQ
-
-### Is the Renoon passport Tod's first Digital Product Passport?
-
-No. Tod's has shipped Digital Product Passports with the Aura Blockchain Consortium since [20 November 2023](https://auraconsortium.com/news/tods-joins-aura-blockchain), starting with the custom Di Bag. The maison extended the same NFC-based Tod's Passport to the My Gommino collection on [14 March 2025](https://www.auraconsortium.com/news/tods-digital-product-passports-to-its-iconic-my-gommino-collection), with traceability by Temera. The Renoon partnership announced on 28 August 2026 adds a second, QR-based data layer.
-
-### What is the difference between Tod's NFC passport and the new QR passport?
-
-They carry different claim sets. The NFC passport, built with Aura and Temera, certifies authenticity and ownership: a secure digital certificate stored on the Aura Private Blockchain, product registration and premium services. The QR passport, built with Renoon, publishes materials, production processes, locations and company certifications — the sustainability and compliance data layer.
-
-### Which passport is the source of truth when a customer scans?
-
-Today, each programme vouches only for its own claims. The NFC chip answers "is this pair genuine and who owns it"; the QR code answers "what is it made of and how was it produced". No public documentation describes a reconciliation layer between the two data layers. WWD reports that Renoon's data will be ensured through the Aura Blockchain Consortium, which suggests a shared integrity anchor — but the architecture is not public.
-
-### Does EU regulation require two passports on one product?
-
-No. Under the ESPR ([Regulation (EU) 2024/1781](https://eur-lex.europa.eu/eli/reg/2024/1781/oj), Articles 9 to 13), each product gets one Digital Product Passport, connected to a persistent unique product identifier. The number of carriers is not fixed: Article 9(2)(b) lets each product group's delegated act define "one or more data carriers" — QR code, NFC tag, or both. For footwear, no delegated act has been adopted yet; according to [Renoon's footwear DPP page](https://www.renoon.com/digital-product-passport-footwear), the European Commission's preparatory study is planned for the end of 2027. Tod's is moving ahead of the mandate — and previewing the interoperability problem every maison will face.
-
-### Can a QR code prove a shoe is authentic?
-
-No. A QR code is a printed, copyable carrier: it links to data, but anyone can photograph and reproduce it. Authenticity requires a cryptographic check that a copy cannot pass — typically a dynamic NFC authentication. Even then, proving the genuine chip is still inside the genuine shoe, the physical-binding problem, remains open engineering work, as we detailed in our [Louisville seizures analysis](/blog/2026-08-27-cbp-louisville-fake-watches-border-enforcement).
+The [Galileo documentation](/docs) can help frame those product-record questions without implying an existing Galileo integration with Tod's, Renoon or Aura.

--- a/website/content/blog/2026-08-29-espr-destruction-ban-luxury-disclosure.mdx
+++ b/website/content/blog/2026-08-29-espr-destruction-ban-luxury-disclosure.mdx
@@ -1,10 +1,14 @@
 ---
-title: "ESPR Destruction Ban: What Luxury Must Now Disclose"
-date: "2026-08-29"
-modified: "2026-08-29"
-author: "Pierre Beunardeau"
-excerpt: "Since 19 July 2026, large enterprises can no longer destroy unsold apparel, clothing accessories and footwear in the EU. A second obligation reaches every maison, including watchmakers and jewelers: Article 24 forces large companies to publish, on their own website, how many unsold products they discard, why, and where those products went. With the derogations and the disclosure format fixed by two Commission acts of 9 February 2026, destroyed volumes are now a public number — comparable across companies once the common format applies in 2027 — and a board-level brand-equity question."
-description: "Since 19 July 2026, large enterprises cannot destroy unsold apparel and footwear in the EU, and every large maison must publish what it discards."
+title: 'ESPR Destruction Ban: What Luxury Must Now Disclose'
+date: '2026-08-29'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  The EU bans destruction of certain unsold goods and requires disclosure of
+  discarded stock. Check product scope, exemptions and reporting dates.
+description: >-
+  The EU bans destruction of certain unsold goods and requires disclosure of
+  discarded stock. Check product scope, exemptions and reporting dates.
 tags:
   - espr
   - regulation
@@ -12,211 +16,79 @@ tags:
   - compliance
   - circularity
 published: true
-coverImage: "/images/blog/espr-destruction-ban-luxury-disclosure.jpg"
-coverImageAlt: "Luxury garments and a watch on a dark obsidian surface under a glowing cyan data overlay suggesting a public disclosure report, tech-noir editorial illustration"
+coverImage: /images/blog/espr-destruction-ban-luxury-disclosure.jpg
+coverImageAlt: >-
+  Dark jackets, shoes and a watch beside illustrated cyan charts on a dark
+  surface
 faq:
-  - question: "Does the ESPR destruction ban apply to watches, jewelry and leather goods?"
-    answer: "The prohibition of Article 25 covers only the products listed in Annex VII: apparel, clothing accessories and footwear. Watches, jewelry and most leather goods are not in Annex VII today, although the Commission can extend the list by delegated act. But the disclosure obligation of Article 24 covers all unsold consumer products. A large watchmaker or jeweler that discards unsold stock must already publish the number, weight, reasons and destination of those products on its website."
-  - question: "When did the ESPR destruction ban take effect?"
-    answer: "The prohibition of Article 25 of Regulation (EU) 2024/1781 applies since 19 July 2026 for large enterprises. Medium-sized enterprises follow from 19 July 2030; micro and small enterprises are exempt. The delegated regulation listing the ten derogations, Commission Delegated Regulation (EU) 2026/296, applies from the same date, 19 July 2026."
-  - question: "What exactly must a large company disclose about unsold products?"
-    answer: "Under Article 24 of the ESPR: the number and weight of unsold consumer products discarded per year, by product type or category; the reasons for discarding and, where applicable, the derogation invoked; the proportion sent to preparing for reuse, recycling, other recovery and disposal; and the measures taken and planned to prevent destruction. The information must sit on an easily accessible page of the company's website, updated annually. Commission Implementing Regulation (EU) 2026/2 sets a standardised format, applicable from 2 March 2027, with disclosure due within 12 months of the end of the financial year."
-  - question: "Can a luxury brand still destroy unsold stock legally?"
-    answer: "Only within the ten derogations of Commission Delegated Regulation (EU) 2026/296: dangerous or non-compliant products, intellectual-property infringement including counterfeits, expired licence restrictions, logos or protected designs that cannot be removed, unacceptable damage or defects that cannot be repaired, refused donations after a documented attempt, and a few residual cases. Each destruction must be documented, and the documentation kept for five years and produced within 30 days at the request of authorities."
-  - question: "When is the first ESPR disclosure due?"
-    answer: "Article 24 has been in force since 18 July 2024, and the first disclosure must cover the first full financial year during which the Regulation was in force. For a company closing its books on 31 December, that is financial year 2025, to be published in 2026. The standardised format of Implementing Regulation (EU) 2026/2 applies to products discarded in financial years from the first full financial year after its date of application, 2 March 2027."
-  - question: "What does public disclosure change for brand equity?"
-    answer: "Destruction volumes stop being an internal supply-chain metric and become a public figure on the maison's own website — directly comparable across companies only once the standardised format of Implementing Regulation (EU) 2026/2 applies, from 2 March 2027. From 19 July 2027, the Commission must also publish consolidated EU-level information on the prevalence of destruction per product group. A maison's discard numbers will be readable by journalists, NGOs, investors and competitors — and judged against its sustainability communication."
+  - question: Are watches covered by the current destruction ban?
+    answer: >-
+      Watches are not among the current Annex VII categories covered by article
+      25. The separate disclosure duty concerns unsold consumer products more
+      broadly, subject to its company-size rules.
+  - question: >-
+      When does the standardised disclosure format first cover a calendar-year
+      business?
+    answer: >-
+      Regulation 2026/2 applies from 2 March 2027 to products discarded from the
+      first full financial year after that date. For a calendar-year business,
+      that means 2028 data, disclosed within twelve months after year-end, by
+      the end of 2029.
+  - question: Does resale automatically count as preparing waste for reuse?
+    answer: >-
+      No. Selling a product before it is discarded can prevent waste. Preparing
+      for reuse is a treatment route for discarded products. The disclosure
+      should reflect the actual route, not treat every second-hand sale as waste
+      treatment.
 ---
+Large businesses must distinguish two ESPR duties: a ban on destroying specified unsold goods, and a broader duty to disclose discarded unsold consumer products. A product outside the current ban can still be relevant to the disclosure.
 
-Since 19 July 2026, large enterprises are prohibited from destroying unsold apparel, clothing accessories and footwear in the EU, under Article 25 of the [ESPR — Regulation (EU) 2024/1781](https://eur-lex.europa.eu/eli/reg/2024/1781/oj). A second, quieter obligation reaches every large maison — including watchmakers and jewelers. Article 24 forces companies that discard unsold consumer products to publish it on their own website: how much they discard, why, and where those products went.
+ESPR is the EU Ecodesign for Sustainable Products Regulation. The [Commission's 17 July 2026 announcement](https://environment.ec.europa.eu/news/ban-destruction-unsold-clothes-and-shoes-enters-application-2026-07-17_en) confirms that the destruction ban began applying on **19 July 2026** for the covered large businesses.
 
-Two Commission acts adopted on 9 February 2026 completed the machinery: the ten derogations that still permit destruction, and the standardised format in which discards will be reported. The operational question for a maison is no longer legal interpretation. It is a board decision — destroy, discount, or channel to certified resale — taken in the knowledge that the numbers will be public.
+## Check the product and the company's size
 
-## Two obligations, not one
+[Article 25 and Annex VII](https://eur-lex.europa.eu/eli/reg/2024/1781/2024-06-28/eng) cover the listed apparel, clothing accessories and footwear. They do not currently impose the same ban on watches or jewellery.
 
-Most coverage of the July milestone mentions only the destruction ban. The ESPR actually stacks three duties, and the distinctions matter for scope.
+Micro and small enterprises are exempt from these article 24 and 25 obligations; the relevant extension to medium-sized enterprises begins on 19 July 2030. The regulation also has a separate prevention duty. Do not use the size exemption as a general instruction to destroy stock without considering other applicable rules.
 
-**Article 23 — prevention, for everyone.** Every economic operator must take the measures that can reasonably be expected to prevent the need to destroy unsold consumer products. No size threshold, no product list.
+Consider a fictional large company with unsold shoes and finished watches. It needs to assess the shoes under the current ban. It should not classify the watches as prohibited merely because they are luxury goods, but discarded unsold watches can still fall within the disclosure duty. Manufacturing components should not automatically be treated as finished consumer products.
 
-**Article 25 — the prohibition, for textiles and footwear.** Since 19 July 2026, destroying unsold products listed in Annex VII is prohibited. Annex VII covers apparel and clothing accessories (CN codes 4203, 61, 62, 6504, 6505) and footwear (CN codes 6401 to 6405). Micro and small enterprises are exempt; medium-sized enterprises follow from 19 July 2030. The Commission can extend Annex VII to other product groups by delegated act — watches and jewelry are not in it today, but the mechanism to add them exists.
+## Record what was discarded and where it went
 
-**Article 24 — disclosure, for all consumer products.** This is the provision luxury boards should read twice. It is not limited to textiles. Any large enterprise that discards unsold consumer products — a watchmaker crushing dials, a jeweler melting stock, a leather-goods house slashing bags — must disclose it publicly. One clarification on the mechanics: Article 24 has been in force since 18 July 2024. Its first disclosure covers the first full financial year in force — financial year 2025 for a company closing on 31 December, published in 2026. The disclosure cycle is not coming. It has started.
+Article 24 concerns quantities and weight, reasons for discarding, treatment destinations and measures to prevent destruction. It is broader than Annex VII.
 
-## What Article 24 forces into the open
+The first disclosure covers the first full financial year after the regulation entered into force on 18 July 2024. For a calendar-year company, that is 2025 information disclosed in 2026.
 
-The disclosure, per Article 24(1), comprises four blocks.
+The standardised format comes later. [Implementing Regulation 2026/2, adopted on 9 February 2026](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32026R0002), applies from 2 March 2027, beginning with the first full financial year after that date. **For a calendar-year company, its first covered year is 2028, with disclosure due by the end of 2029.** The existing disclosure duty does not wait for that format.
 
-- **Volumes**: the number and weight of unsold consumer products discarded per year, differentiated per type or category of products.
-- **Reasons**: why the products were discarded, and where applicable the derogation invoked under Article 25(5).
-- **Destinations**: the proportion of discarded products sent to each step of the waste hierarchy — preparing for reuse (including refurbishment and remanufacturing), recycling, other recovery including energy recovery, and disposal.
-- **Prevention**: measures taken, and measures planned, to prevent destruction of unsold products.
+This distinction matters when comparing companies. A legal application date is not the date on which every company publishes a first table in a common format.
 
-Publication must be "in a clear and visible manner at least on an easily accessible page" of the company's website, renewed annually, with each year's information kept publicly available. Companies already publishing sustainability reporting under the CSRD (Articles 19a or 29a of Directive 2013/34/EU) may fold the disclosure into it. Micro and small enterprises are exempt; medium-sized enterprises join from 19 July 2030.
+## A permitted exception needs its own evidence
 
-[Commission Implementing Regulation (EU) 2026/2](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32026R0002), adopted on 9 February 2026, fixes the details. Its Annex I defines a standardised table per product category: units discarded, total weight in kilograms, and a yes/no flag on packaging included in the weight. It adds the reason for discarding and the percentages routed to each treatment operation — with an explicit "destruction" column and an "unknown" column. Product categories follow the combined nomenclature codes used in customs declarations. Disclosure is due within 12 months of the end of the financial year. The regulation applies from 2 March 2027, to products discarded in financial years from the first full financial year after that date. Until then, the base Article 24 obligation already applies, in free but "clear and visible" form.
+[Delegated Regulation 2026/296](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32026R0296) sets narrowly defined derogations from the destruction ban. A desire to protect scarcity or price is not, on its own, a general exemption.
 
-Then the numbers leave the company website. By 19 July 2027, and every 36 months after, the Commission must publish consolidated information on the prevalence of destruction per product group, built on these disclosures (Article 26). Note the scope: the consolidation is by product group, not by company — an industry-level prevalence picture, not a public ranking of maisons.
+For example, the donation route in article 2(h) includes conditions concerning an offer to at least three suitable social-economy entities **or** an accessible offer on the company's website, for at least eight weeks. It is subject to the provision's other conditions, including the relationship to the preceding derogations. A checklist containing only “three organisations contacted” would omit a lawful alternative and the remaining requirements.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 470" role="img" aria-label="Timeline of the ESPR unsold-goods rules. 18 July 2024: the ESPR enters into force and the Article 24 disclosure duty starts, first covering the first full financial year in force. 9 February 2026: the Commission adopts Delegated Regulation (EU) 2026/296 on derogations and Implementing Regulation (EU) 2026/2 on the disclosure format. 2026: first Article 24 disclosures are published by large enterprises. 19 July 2026: the destruction ban for apparel, accessories and footwear applies to large enterprises, and the derogations regulation applies. 2 March 2027: the standardised Annex I disclosure format applies. 19 July 2027: the Commission publishes the first consolidated EU picture of destruction per product group. 19 July 2030: medium-sized enterprises enter the scope of both obligations." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="28" fontSize="14" fontWeight="600" fill="#FFFFFF">Unsold goods: the ESPR calendar</text>
-    <line x1="96" y1="46" x2="96" y2="456" stroke="#062840" strokeWidth="2" />
-    <text x="86" y="64" textAnchor="end" fontSize="10.5" fontWeight="600" fill="#22D3EE">18 Jul 2024</text>
-    <circle cx="96" cy="60" r="4.5" fill="#00FFFF" />
-    <text x="112" y="58" fontSize="11" fill="rgba(255, 255, 255, 0.75)">ESPR in force; Article 24 disclosure</text>
-    <text x="112" y="72" fontSize="11" fill="rgba(255, 255, 255, 0.75)">duty starts (first full FY in force)</text>
-    <text x="86" y="126" textAnchor="end" fontSize="10.5" fontWeight="600" fill="#22D3EE">9 Feb 2026</text>
-    <circle cx="96" cy="122" r="4.5" fill="#00FFFF" />
-    <text x="112" y="120" fontSize="11" fill="rgba(255, 255, 255, 0.75)">Derogations act (EU) 2026/296 and</text>
-    <text x="112" y="134" fontSize="11" fill="rgba(255, 255, 255, 0.75)">format act (EU) 2026/2 adopted</text>
-    <text x="86" y="188" textAnchor="end" fontSize="10.5" fontWeight="600" fill="#22D3EE">2026</text>
-    <circle cx="96" cy="184" r="4.5" fill="#00FFFF" />
-    <text x="112" y="182" fontSize="11" fill="rgba(255, 255, 255, 0.75)">First Article 24 disclosures go public</text>
-    <text x="112" y="196" fontSize="11" fill="rgba(255, 255, 255, 0.75)">(FY 2025 for calendar-year groups)</text>
-    <text x="86" y="250" textAnchor="end" fontSize="10.5" fontWeight="600" fill="#22D3EE">19 Jul 2026</text>
-    <circle cx="96" cy="246" r="5.5" fill="#22D3EE" />
-    <text x="112" y="244" fontSize="11" fill="rgba(255, 255, 255, 0.75)">Destruction ban binds large enterprises;</text>
-    <text x="112" y="258" fontSize="11" fill="rgba(255, 255, 255, 0.75)">derogations regulation applies</text>
-    <text x="86" y="312" textAnchor="end" fontSize="10.5" fontWeight="600" fill="#22D3EE">2 Mar 2027</text>
-    <circle cx="96" cy="308" r="4.5" fill="#00FFFF" />
-    <text x="112" y="306" fontSize="11" fill="rgba(255, 255, 255, 0.75)">Standardised Annex I disclosure</text>
-    <text x="112" y="320" fontSize="11" fill="rgba(255, 255, 255, 0.75)">format applies</text>
-    <text x="86" y="374" textAnchor="end" fontSize="10.5" fontWeight="600" fill="#22D3EE">19 Jul 2027</text>
-    <circle cx="96" cy="370" r="4.5" fill="#00FFFF" />
-    <text x="112" y="368" fontSize="11" fill="rgba(255, 255, 255, 0.75)">Commission publishes consolidated</text>
-    <text x="112" y="382" fontSize="11" fill="rgba(255, 255, 255, 0.75)">EU picture per product group</text>
-    <text x="86" y="436" textAnchor="end" fontSize="10.5" fontWeight="600" fill="#22D3EE">19 Jul 2030</text>
-    <circle cx="96" cy="432" r="4.5" fill="#00FFFF" />
-    <text x="112" y="436" fontSize="11" fill="rgba(255, 255, 255, 0.75)">Medium-sized enterprises in scope</text>
-  </svg>
-</div>
+Keep the reason, supporting documents and actual treatment route together. A product passport may help identify the item; it does not grant permission to destroy it.
 
-## The ten derogations: what still permits destruction
+## Separate prevention from waste treatment
 
-[Commission Delegated Regulation (EU) 2026/296](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32026R0296), adopted on 9 February 2026 and applicable from 19 July 2026, lists the ten exhaustive circumstances in which Annex VII products may still be destroyed. Compressed, they cover:
+If the fictional company sells its shoes before discarding them, it may prevent waste. That sale does not automatically increase the “preparing for reuse” share in a table describing discarded products and their waste-treatment destinations.
 
-1. **Dangerous products** under the General Product Safety Regulation (EU) 2023/988.
-2. **Non-compliant products** whose destruction is required by law or is the proportionate corrective action.
-3. **IP-infringing products**, including counterfeits, established by a decision, a right-holder notification or a substantiated internal investigation.
-4. **Expired licence restrictions**: a contract bars any transfer of the product after a period that has now lapsed.
-5. **Logos and protected designs that cannot be removed** or made permanently inaccessible, making reuse or remanufacturing unsuitable.
-6. **Unacceptable damage, deterioration or contamination**, where repair is technically impossible or not cost-effective.
-7. **Design or manufacturing defects** that cannot be repaired.
-8. **Refused donations**: the product was offered to at least three suitable social economy entities in the EU, or on an easily accessible page of the company's website, for at least eight weeks — and nobody took it.
-9. **Donations that found no recipient** after reaching a social economy entity.
-10. **Products prepared for reuse** by a waste treatment operator for which no recipient could be found.
+For the same reason, a certified resale channel is not a universal compliance solution. The company must describe what actually happened to the goods and assess the applicable rule.
 
-Three of these derogations cut both ways for luxury. Derogation 3 covers the counterfeit seizures a maison legitimately destroys. Derogation 5 is the historical brand-protection play — goods destroyed because de-logoing is not technically feasible — now narrowed to genuine technical infeasibility, not preference. Derogation 8 turns donation into a compliance gateway: a documented, eight-week, three-entity offer that fails becomes a legal basis for destruction, but it also becomes a disclosed data point.
+## Frequently asked questions
 
-Every derogation carries a paper trail. Article 3 of the delegated regulation requires documentation per derogation type: test reports, self-assessment statements, judicial decisions, licence contracts, inspection reports. The file must be kept for five years and produced within 30 days at the request of authorities. And destruction must follow the waste hierarchy, prioritising recycling over energy recovery and disposal. "We destroyed it" without a file is now a compliance violation, not an inventory adjustment.
+### Are watches covered by the current destruction ban?
 
-## Destroy, discount, or recommerce: the board decision
+Watches are not among the current Annex VII categories covered by article 25. The separate disclosure duty concerns unsold consumer products more broadly, subject to its company-size rules.
 
-With the legal frame fixed, the choice for unsold Annex VII stock reduces to three routes — each with a distinct disclosure footprint and brand-equity price.
+### When does the standardised disclosure format first cover a calendar-year business?
 
-| Route | Legal condition | What the public sees | Brand-equity cost |
-| --- | --- | --- | --- |
-| Destroy under derogation | One of ten derogations, documented for five years | Volumes, weight, reasons and % destroyed in the annual Article 24 disclosure | Highest: destruction numbers become public |
-| Discount and alternative channels | Not prohibited by Article 25 — other applicable law still applies | Lower discard volumes in the next disclosure | Markdowns erode pricing power and full-price wait-lists |
-| Donate or channel to certified resale | Documented donation process; controlled secondary channel | High % routed to reuse in the disclosure | Channel leakage if resale is not curated and authenticated |
+Regulation 2026/2 applies from 2 March 2027 to products discarded from the first full financial year after that date. For a calendar-year business, that means 2028 data, disclosed within twelve months after year-end, by the end of 2029.
 
-The disclosure column is what changed this summer. Scarcity management used to be invisible: stock quietly written off, incinerated off-site, reported nowhere. Article 24 makes the discard figure a public line item on the maison's own website, and Article 26 will aggregate it across the EU. A maison that destroys 8% of its unsold apparel while marketing circularity will read that number in the press, not in its ERP.
+### Does resale automatically count as preparing waste for reuse?
 
-The scale at stake is not marginal. According to the [European Commission](https://environment.ec.europa.eu/news/ban-destruction-unsold-clothes-and-shoes-enters-application-2026-07-17_en), citing the European Environment Agency, an estimated 4 to 9% of textiles sold in Europe are destroyed before use. That is between 264,000 and 594,000 tonnes per year.
+No. Selling a product before it is discarded can prevent waste. Preparing for reuse is a treatment route for discarded products. The disclosure should reflect the actual route, not treat every second-hand sale as waste treatment.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 320" role="img" aria-label="Decision flow for unsold apparel and footwear at a large enterprise. Unsold stock faces three legal paths. Destroy: only if one of the ten derogations of Delegated Regulation (EU) 2026/296 applies, with documentation kept five years. Discount: markdowns and alternative channels, not prohibited by Article 25 though other applicable law still applies, at a pricing-power cost. Donate or prepare for reuse: a documented eight-week offer to at least three social economy entities can itself become the donation derogation. Whichever path is chosen, volumes, reasons and destinations land in the annual public disclosure under Article 24 of the ESPR." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="26" fontSize="14" fontWeight="600" fill="#FFFFFF">Unsold stock: three legal paths, one public ledger</text>
-    <rect x="120" y="42" width="200" height="34" rx="6" fill="#00FFFF" opacity="0.12" />
-    <text x="220" y="56" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#FFFFFF">Unsold apparel &amp; footwear</text>
-    <text x="220" y="69" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.6)">large enterprise, Annex VII</text>
-    <line x1="170" y1="76" x2="75" y2="102" stroke="#062840" strokeWidth="1.5" />
-    <line x1="220" y1="76" x2="220" y2="102" stroke="#062840" strokeWidth="1.5" />
-    <line x1="270" y1="76" x2="365" y2="102" stroke="#062840" strokeWidth="1.5" />
-    <rect x="20" y="102" width="128" height="110" rx="6" fill="#0E7490" opacity="0.35" />
-    <text x="84" y="122" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#FFFFFF">Destroy</text>
-    <text x="84" y="140" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Only under one of</text>
-    <text x="84" y="153" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">10 derogations</text>
-    <text x="84" y="166" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">(Reg. 2026/296)</text>
-    <text x="84" y="186" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">Documentation kept</text>
-    <text x="84" y="198" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">5 years, 30-day request</text>
-    <rect x="156" y="102" width="128" height="110" rx="6" fill="#0E7490" opacity="0.35" />
-    <text x="220" y="122" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#FFFFFF">Discount</text>
-    <text x="220" y="140" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Markdowns, outlets,</text>
-    <text x="220" y="153" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">alternative channels</text>
-    <text x="220" y="166" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Not banned by Art. 25</text>
-    <text x="220" y="186" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">Cost: pricing power</text>
-    <text x="220" y="198" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">and scarcity</text>
-    <rect x="292" y="102" width="128" height="110" rx="6" fill="#0E7490" opacity="0.35" />
-    <text x="356" y="122" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#FFFFFF">Donate / reuse</text>
-    <text x="356" y="140" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Donation, repair,</text>
-    <text x="356" y="153" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">certified resale</text>
-    <text x="356" y="166" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Refusal = derogation 8</text>
-    <text x="356" y="186" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">3 entities, 8 weeks,</text>
-    <text x="356" y="198" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">documented offer</text>
-    <line x1="84" y1="212" x2="84" y2="238" stroke="#062840" strokeWidth="1.5" />
-    <line x1="220" y1="212" x2="220" y2="238" stroke="#062840" strokeWidth="1.5" />
-    <line x1="356" y1="212" x2="356" y2="238" stroke="#062840" strokeWidth="1.5" />
-    <rect x="60" y="238" width="320" height="46" rx="6" fill="#041c30" stroke="rgba(0, 255, 255, 0.35)" strokeWidth="1" />
-    <text x="220" y="257" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#22D3EE">Annual public disclosure — ESPR Article 24</text>
-    <text x="220" y="273" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.7)">Volumes, weight, reasons, % per destination, prevention measures</text>
-    <text x="20" y="308" fontSize="9.5" fill="rgba(255, 255, 255, 0.55)">Sources: Regulation (EU) 2024/1781 arts. 24-25; Delegated Regulation (EU) 2026/296.</text>
-  </svg>
-</div>
-
-## What public numbers do to brand equity
-
-Luxury's historical rationale for destruction was protection: of scarcity, of price integrity, of the grey-market boundary. The ESPR does not forbid the rationale — it prices it. For Annex VII products at a large enterprise, destruction is now lawful only under a derogation. Each derogation-based destruction must be documented, with the file kept five years — and it still surfaces as a public figure with a stated reason in the annual disclosure.
-
-Three second-order effects follow. **Comparability — but not yet**: the standardised table of Implementing Regulation (EU) 2026/2 applies only from 2 March 2027, for financial years from the first full financial year after that date. Until then, disclosures follow no common format and are not directly comparable across companies. Once the format binds, discard figures will be line-comparable across the industry, by product category, in kilograms and units. **Narrative exposure**: the "unknown" and "destruction" columns exist precisely to make vague answers visible; an unexplained gap is itself a story. **Prevention as a public commitment**: the disclosure includes measures planned, so next year's table reads as a scorecard against this year's promises.
-
-The strategic inversion is worth stating plainly. A maison that routes unsold stock to a certified, authenticated secondary channel converts a disclosure liability into a reuse percentage it will want to publish. That requires knowing, item by item, what left the primary channel, in what condition, and into whose hands. It is the same verifiable item-level identity that powers authentication and [the coming Digital Product Passport](/blog/2026-08-25-eu-dpp-registry-live).
-
-## The limits of what we know
-
-Intellectual honesty about this file.
-
-- **Enforcement practice is unwritten.** Penalties are set by member states; how actively national authorities will audit disclosures and derogation files is not yet predictable.
-- **Disclosure is volume, not value.** The format asks for units and kilograms, not retail value. Destroyed value will be inferred by journalists, not reported by maisons.
-- **The standardised format lands later than the duty.** Article 24 disclosures are due now, but the Annex I format applies only from 2 March 2027, for financial years from the first full financial year after that date. Early disclosures will vary in shape.
-- **Scope will move.** Annex VII covers textiles and footwear today; Article 25(3) lets the Commission add product groups based on the very disclosures Article 24 collects. Watch and jewelry discard figures, published from this cycle on, are the evidence base for any future extension.
-- **Aggregation starts in 2027.** The Commission's first consolidated publication under Article 26 is due by 19 July 2027; its methodology and granularity are not yet public.
-
-## Galileo's take
-
-**Galileo's take: the destruction ban is the first ESPR obligation with reputational teeth, and disclosure is the sharper edge.** The ban constrains one category; the disclosure exposes all of them. Maisons that treat Article 24 as a reporting chore will publish a number once a year and spend the other 364 days hoping nobody reads it. Maisons that treat it as a forcing function will redesign the end of the product life they control: certified resale with authenticated items, documented donation, repair over write-off. Their reuse percentage will read as proof, not apology. That is precisely the infrastructure Galileo Protocol builds: item-level digital twins, interoperable attestations for lifecycle events, personal data off-chain, schemas published openly in our [specifications](/specifications). Explore the [documentation](/docs) or [contact us](mailto:info@galileoprotocol.io) to design a certified-resale or end-of-life channel your next disclosure can be proud of.
-
-## Sources
-
-- [Regulation (EU) 2024/1781 (ESPR), EUR-Lex](https://eur-lex.europa.eu/eli/reg/2024/1781/oj), 13 June 2024: Article 23 (prevention duty), Article 24 (disclosure fields, website publication, annual cycle, first disclosure covering the first full financial year in force, micro/small exemption, medium-sized from 19 July 2030), Article 25 (prohibition from 19 July 2026, Annex VII scope, delegated-act power to extend), Article 26 (Commission consolidated publication by 19 July 2027), Annex VII (CN codes 4203, 61, 62, 6504, 6505, 6401-6405). Consulted 29 August 2026.
-- [Commission Delegated Regulation (EU) 2026/296, EUR-Lex](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32026R0296), 9 February 2026, published in the Official Journal on 22 April 2026: ten exhaustive derogations (Article 2), including the donation derogation (three social economy entities or website offer, eight weeks) and the logo-removal derogation; documentation kept five years, produced within 30 days (Article 3); applicable from 19 July 2026. Consulted 29 August 2026.
-- [Commission Implementing Regulation (EU) 2026/2, EUR-Lex](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32026R0002), 9 February 2026, published in the Official Journal on 10 February 2026: Annex I standardised disclosure format (units, weight, packaging flag, reasons, percentages per treatment route including destruction and unknown, prevention measures), disclosure within 12 months of financial year end, CN-code delimitation, applicable from 2 March 2027. Consulted 29 August 2026.
-- [European Commission, ESPR page](https://commission.europa.eu/energy-climate-change-environment/standards-tools-and-labels/products-labelling-rules-and-requirements/ecodesign-sustainable-products-regulation_en): adoption of the implementing and delegated acts on destruction of unsold consumer products on 9 February 2026; disclosure duty applying across all product sectors. Consulted 29 August 2026.
-- [European Commission, Ban on destruction of unsold clothes and shoes enters into application](https://environment.ec.europa.eu/news/ban-destruction-unsold-clothes-and-shoes-enters-application-2026-07-17_en), 17 July 2026: application from 19 July 2026, medium-sized companies from 2030, five-year record keeping, EEA estimate of 4-9% of textiles destroyed before use (264,000-594,000 tonnes per year). Consulted 29 August 2026.
-
-## FAQ
-
-### Does the ESPR destruction ban apply to watches, jewelry and leather goods?
-
-The prohibition of Article 25 covers only the products listed in Annex VII: apparel, clothing accessories and footwear. Watches, jewelry and most leather goods are not in Annex VII today, although the Commission can extend the list by delegated act. But the disclosure obligation of Article 24 covers all unsold consumer products. A large watchmaker or jeweler that discards unsold stock must already publish the number, weight, reasons and destination of those products on its website.
-
-### When did the ESPR destruction ban take effect?
-
-The prohibition of Article 25 of [Regulation (EU) 2024/1781](https://eur-lex.europa.eu/eli/reg/2024/1781/oj) applies since 19 July 2026 for large enterprises. Medium-sized enterprises follow from 19 July 2030; micro and small enterprises are exempt. The delegated regulation listing the ten derogations, [Commission Delegated Regulation (EU) 2026/296](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32026R0296), applies from the same date, 19 July 2026.
-
-### What exactly must a large company disclose about unsold products?
-
-Under Article 24 of the ESPR: the number and weight of unsold consumer products discarded per year, by product type or category; the reasons for discarding and, where applicable, the derogation invoked; the proportion sent to preparing for reuse, recycling, other recovery and disposal; and the measures taken and planned to prevent destruction. The information must sit on an easily accessible page of the company's website, updated annually. [Commission Implementing Regulation (EU) 2026/2](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32026R0002) sets a standardised format, applicable from 2 March 2027, with disclosure due within 12 months of the end of the financial year.
-
-### Can a luxury brand still destroy unsold stock legally?
-
-Only within the ten derogations of [Commission Delegated Regulation (EU) 2026/296](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32026R0296): dangerous or non-compliant products, intellectual-property infringement including counterfeits, expired licence restrictions, logos or protected designs that cannot be removed, unacceptable damage or defects that cannot be repaired, refused donations after a documented attempt, and a few residual cases. Each destruction must be documented, and the documentation kept for five years and produced within 30 days at the request of authorities.
-
-### When is the first ESPR disclosure due?
-
-Article 24 has been in force since 18 July 2024, and the first disclosure must cover the first full financial year during which the Regulation was in force. For a company closing its books on 31 December, that is financial year 2025, to be published in 2026. The standardised format of Implementing Regulation (EU) 2026/2 applies to products discarded in financial years from the first full financial year after its date of application, 2 March 2027.
-
-### What does public disclosure change for brand equity?
-
-Destruction volumes stop being an internal supply-chain metric and become a public figure on the maison's own website — directly comparable across companies only once the standardised format of Implementing Regulation (EU) 2026/2 applies, from 2 March 2027. From 19 July 2027, the Commission must also publish consolidated EU-level information on the prevalence of destruction per product group. A maison's discard numbers will be readable by journalists, NGOs, investors and competitors — and judged against its sustainability communication.
+The [Galileo documentation](/docs) explains how product records may support this evidence trail. Start with the legal scope and stock records before choosing the technology.

--- a/website/content/blog/2026-08-30-fpjourne-secondary-market-portable-proof.mdx
+++ b/website/content/blog/2026-08-30-fpjourne-secondary-market-portable-proof.mdx
@@ -1,10 +1,14 @@
 ---
-title: "F.P. Journe Asks to Be Called First: The Portable Proof Gap"
-date: "2026-08-30"
-modified: "2026-08-30"
-author: "Pierre Beunardeau"
-excerpt: "F.P. Journe displays a public warning on its own official site: the watches, clocks and related products shown are counterfeits, and collectors should contact the manufacture before purchasing. The institutional answer exists — a nominative Certificate of Authenticity issued through its Boutiques, and a Patrimoine service that buys back, restores and resells rare pieces with a new three-year warranty. What the public pages do not describe is a proof that travels with the watch and that a buyer could verify independently at the moment of the transaction."
-description: "F.P. Journe warns collectors on its own site: contact us before purchasing. Its certificate is nominative; no portable proof is publicly documented."
+title: 'Buying F.P. Journe Pre-Owned: What the Records Prove'
+date: '2026-08-30'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  A pre-owned watch needs more than a certificate image. Understand F.P.
+  Journe's published services and the checks a buyer should keep separate.
+description: >-
+  A pre-owned watch needs more than a certificate image. Understand F.P.
+  Journe's published services and the checks a buyer should keep separate.
 tags:
   - counterfeiting
   - luxury
@@ -12,171 +16,75 @@ tags:
   - authentication
   - provenance
 published: true
-coverImage: "/images/blog/fpjourne-secondary-market-portable-proof.jpg"
-coverImageAlt: "A mechanical luxury watch on a dark obsidian surface with a translucent cyan holographic verification shield hovering above it, tech-noir editorial illustration"
+coverImage: /images/blog/fpjourne-secondary-market-portable-proof.jpg
+coverImageAlt: A mechanical watch on a dark surface beneath an illustrated cyan shield
 faq:
-  - question: "Did F.P. Journe really publish an anti-counterfeit warning?"
-    answer: "Yes, on its own official website. As of 30 August 2026, the homepage of fpjourne.com opens a warning popup. It states that the watches, clocks and related products shown are counterfeits, and advises collectors to exercise the utmost vigilance and contact the manufacture before purchasing. A count of flagged items circulates in secondary coverage, but no dated, archivable statement from the manufacture fixes a number. We rely only on the banner displayed on the official site."
-  - question: "What is the F.P. Journe Certificate of Authenticity?"
-    answer: "According to the manufacture's warranty FAQ, a certificate of authenticity can be issued for any timepiece sold more than five years before the request. The watch must be certified by an F.P. Journe Boutique, and the document is established on a nominative basis — made out to a named person. The service page routes requests through the Boutiques: 'Nous vous invitons à contacter une Boutique F.P.Journe.'"
-  - question: "Is the F.P. Journe certificate transferable when the watch is resold?"
-    answer: "The public documentation does not say. The certificate is nominative: it attests, for a named requester, that a specific watch was examined and certified by the manufacture. The manufacture's public pages describe no transfer mechanism at resale, and no way for a buyer to verify a certificate independently at the moment of the transaction. That is a documentation gap, not proof that no mechanism exists."
-  - question: "What is the F.P. Journe Patrimoine service?"
-    answer: "Created in 2016, the Patrimoine service is the manufacture's own secondary-market channel. F.P. Journe buys back rare watches in good condition that are no longer in production. It restores case and movement to their original state, and resells them on request through its Boutiques with a new three-year sales warranty."
-  - question: "What would a portable proof change for the secondary market?"
-    answer: "Verification would travel with the watch. A buyer, dealer or auction house could check item-level authenticity at the moment of the transaction, without routing through the manufacture. The proof would pass from seller to buyer with ownership. The manufacture's authority would be exercised once, at issuance, instead of being re-invoked for every resale."
+  - question: Who can request an F.P. Journe authenticity certificate?
+    answer: >-
+      The manufacture's warranty FAQ says a certificate can be requested for a
+      timepiece sold more than five years before the request. The watch must be
+      certified by an F.P. Journe Boutique, and the document is made out to a
+      named person.
+  - question: Does a nominative certificate require a new examination at every resale?
+    answer: >-
+      That conclusion does not follow from the word nominative. Ask the
+      manufacture how an existing certificate can be checked and what applies to
+      the proposed transaction. Its public description does not settle every
+      resale situation.
+  - question: What is the Patrimoine service?
+    answer: >-
+      F.P. Journe describes Patrimoine, created in 2016, as its channel for
+      buying back rare watches no longer in production, restoring them and
+      reselling them through its boutiques with a three-year sales warranty.
 ---
+A buyer of a pre-owned F.P. Journe should establish what each document covers, then assess the watch and the seller separately. A certificate, a service history and a warranty answer different questions; none should silently stand in for the others.
 
-F.P. Journe displays a warning on its own official website: the watches, clocks and related products shown are counterfeits, and collectors should "exercise the utmost vigilance and contact us before purchasing". The Geneva manufacture has built a serious institutional answer to fakes — but none of its public pages describes a proof that travels with the watch.
+The manufacture's published services provide a starting point. They do not justify assuming that every resale needs a newly issued certificate, or that a past certificate guarantees the watch's present condition.
 
-The instrument the public documentation does not describe — a portable proof, verifiable at the moment of the transaction — is the real subject of this week's story.
+## The services F.P. Journe describes
 
-## What the manufacture published
+The [official warranty FAQ](https://www.fpjourne.com/fr/garantie), consulted on 12 September 2026, says an authenticity certificate can be requested for a timepiece sold more than five years earlier. The watch must be certified by an F.P. Journe Boutique, and the document is nominative: it is made out to a named person.
 
-The warning lives on the homepage of [fpjourne.com](https://www.fpjourne.com/en), as a modal popup displayed to visitors. We accessed it directly on 30 August 2026 and archived the page (screenshot and full HTML). Its text is unambiguous:
+That five-year condition concerns when a certificate may be requested. It is not a general five-year warranty for every watch.
 
-> "Attention: all of these watches, clocks and related products are counterfeits."
-> "To all our collectors: due to the rise in counterfeit items, we advise you to exercise the utmost vigilance and contact us before purchasing."
-> "Do not purchase without the expertise of a professional."
+The [Patrimoine page](https://www.fpjourne.com/fr/patrimoine) describes a programme created in 2016 for rare watches no longer in production. The manufacture buys back eligible pieces, restores them and offers them through its boutiques with a new three-year sales warranty.
 
-Below the text, a grid of photographs shows the flagged objects, each stamped "FAKE": wall clocks, a key ring, a Brioni-branded item, presentation boxes, and watches photographed face and caseback. One precision on sourcing: a specific count of flagged items circulates in secondary coverage, but we found no dated, archivable statement from the manufacture that fixes a number. We therefore describe the banner without a count. If the banner is later removed, what remains is that the manufacture publicly flagged several products as counterfeits on its official site.
+These are documented routes to manufacturer involvement. The conditions of a particular purchase or service still need to be checked with the relevant boutique.
 
-The story surfaced in the trade press on 28 August 2026, when [WatchPro USA published "Beware of super-fakes warns F.P. Journe"](https://usa.watchpro.com/beware-of-super-fakes-warns-f-p-journe/) (title and date confirmed via Google News; the article itself sits behind a bot wall and could not be re-read in full). A [luxe.net piece dated 29 August 2026](https://luxe.net/f-p-journe-contrefacon-collectionneurs/) attributes the warning to the manufacture's social networks — while itself flagging that it could not access the brand's site or accounts directly. We could not find a dated, archivable social post from the manufacture either; the verifiable artefact is the popup on the official site. The [F.P. Journe press area](https://www.fpjourne.com/en/press-area), checked the same day, shows no dedicated anti-counterfeit dossier.
+## Read the document before drawing a conclusion
 
-## The institutional answer: certificate, network, Patrimoine
+Consider a fictional collector buying a watch from a private seller. The seller supplies a photograph of a certificate made out to someone else.
 
-The manufacture is not merely warning. Its official site documents three instruments.
+The buyer should first ask for enough information to establish which watch the certificate describes and how its origin can be confirmed through a known manufacturer channel. A name on the document does not, by itself, establish that only that person may present it or that no verification route exists for a later buyer.
 
-**The Certificate of Authenticity.** The [service page](https://www.fpjourne.com/fr/service) closes its ten-step service description with a dedicated block: "CERTIFICAT D'AUTHENTICITÉ — Nous vous invitons à contacter une Boutique F.P.Journe." The [warranty FAQ](https://www.fpjourne.com/fr/garantie) gives the precise regime. A certificate can be issued for any timepiece sold more than five years before the request, the watch must be certified by an F.P. Journe Boutique, and "ce document est établi de manière nominative" — it is made out to a named person.
+The buyer also needs to know what happened after the certificate was issued. Repairs, replaced components and damage may matter to today's assessment. An accurate historical certificate can coexist with a later change in condition.
 
-**The official network as a shield.** The same FAQ answers why one should buy from an authorised point of sale. You are assured of a new, manufacture-guaranteed watch at the recommended price, and "vous éviterez la contrefaçon et l'achat d'une montre volée" — you avoid counterfeits and buying a stolen watch.
+Finally, the seller's right to sell is a separate question. An authenticity assessment does not by itself establish the ownership trail or the terms of the proposed sale.
 
-**The Patrimoine service.** Since 2016, the manufacture runs its own secondary-market channel, described on its [Patrimoine page](https://www.fpjourne.com/fr/patrimoine): F.P. Journe buys back rare, out-of-production watches in good condition, guarantees their original state (case and movement), and resells them on request through its Boutiques with a new three-year sales warranty. The [current Patrimoine inventory](https://www.fpjourne.com/fr/patrimoine-le-bilan) lists dozens of pieces, each "révisée à la Manufacture" and delivered with certificate or warranty card.
+## What a portable record could improve
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 316" role="img" aria-label="Diagram of the verification paths available to a secondary-market buyer of an F.P. Journe watch today. Path one: contact a Boutique for a Certificate of Authenticity — the watch must be certified by the Boutique, it is available only for timepieces sold more than five years ago, and the document is nominative, made out to the requester. Path two: buy through the Patrimoine service — the manufacture buys back, restores and resells with a three-year warranty, but only for rare out-of-production pieces inside its own channel. Path three: trust the seller and available papers — this is where the warning popup asks collectors to contact the manufacture before purchasing, drawn as the unprotected path." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="26" fontSize="14" fontWeight="600" fill="#FFFFFF">Buying pre-owned today: three verification paths</text>
-    <rect x="110" y="42" width="220" height="32" rx="6" fill="#00FFFF" opacity="0.12" />
-    <text x="220" y="62" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#FFFFFF">Collector eyes a pre-owned F.P. Journe</text>
-    <line x1="160" y1="74" x2="75" y2="100" stroke="#062840" strokeWidth="1.5" />
-    <line x1="220" y1="74" x2="220" y2="100" stroke="#062840" strokeWidth="1.5" />
-    <line x1="280" y1="74" x2="365" y2="100" stroke="#062840" strokeWidth="1.5" />
-    <rect x="20" y="100" width="128" height="118" rx="6" fill="#0E7490" opacity="0.35" />
-    <text x="84" y="119" textAnchor="middle" fontSize="10" fontWeight="600" fill="#FFFFFF">Certificate of</text>
-    <text x="84" y="131" textAnchor="middle" fontSize="10" fontWeight="600" fill="#FFFFFF">Authenticity</text>
-    <text x="84" y="149" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Via a Boutique,</text>
-    <text x="84" y="161" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">watch over 5 years old</text>
-    <text x="84" y="173" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Nominative document</text>
-    <text x="84" y="191" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">Made out to a named</text>
-    <text x="84" y="203" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">requester (brand FAQ)</text>
-    <rect x="156" y="100" width="128" height="118" rx="6" fill="#0E7490" opacity="0.35" />
-    <text x="220" y="119" textAnchor="middle" fontSize="10" fontWeight="600" fill="#FFFFFF">Patrimoine service</text>
-    <text x="220" y="149" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Buyback, Manufacture</text>
-    <text x="220" y="161" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">restoration, resale in</text>
-    <text x="220" y="173" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Boutiques, 3-yr warranty</text>
-    <text x="220" y="191" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">Only rare, out-of-</text>
-    <text x="220" y="203" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">production pieces</text>
-    <rect x="292" y="100" width="128" height="118" rx="6" fill="none" stroke="#22D3EE" strokeWidth="1" strokeDasharray="5 4" opacity="0.8" />
-    <text x="356" y="119" textAnchor="middle" fontSize="10" fontWeight="600" fill="#FFFFFF">Trust the seller</text>
-    <text x="356" y="149" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">Papers, boxes,</text>
-    <text x="356" y="161" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">reputation, visual</text>
-    <text x="356" y="173" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.75)">expertise</text>
-    <text x="356" y="191" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">The path the warning</text>
-    <text x="356" y="203" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.55)">popup is about</text>
-    <line x1="84" y1="218" x2="84" y2="244" stroke="#062840" strokeWidth="1.5" />
-    <line x1="220" y1="218" x2="220" y2="244" stroke="#062840" strokeWidth="1.5" />
-    <line x1="356" y1="218" x2="356" y2="244" stroke="#22D3EE" strokeWidth="1" strokeDasharray="4 3" opacity="0.6" />
-    <rect x="52" y="244" width="336" height="42" rx="6" fill="#041c30" stroke="rgba(0, 255, 255, 0.35)" strokeWidth="1" />
-    <text x="220" y="261" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">No portable proof appears in the public documentation</text>
-    <text x="220" y="276" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.7)">No public page describes verification or transfer at resale</text>
-    <text x="20" y="306" fontSize="9.5" fill="rgba(255, 255, 255, 0.55)">Sources: fpjourne.com service, warranty FAQ and Patrimoine pages, linked inline.</text>
-  </svg>
-</div>
+A portable record is information that the next recipient can read and check without depending entirely on the previous owner's screenshot. It could connect the item identifier, issuer, statement and later service records.
 
-## What the public documentation does not say
+In the fictional sale, that might help the buyer establish where a service claim came from and whether it was replaced. It would still need a reliable association with the watch and an explanation of the claim's scope. A digital signature cannot prevent a physical substitution or make an old condition assessment current.
 
-Read the regime again, from the buyer's side of a private sale.
+The public F.P. Journe pages do not describe every mechanism for that journey. This proposed example is therefore not a description of the manufacture's internal system or a Galileo deployment.
 
-The certificate is **boutique-mediated**: obtaining the manufacture's word means routing the physical watch, or its owner, through an F.P. Journe Boutique. It is **time-gated**: only timepieces sold more than five years ago are eligible. Above all, it is **nominative**: it attests to a named requester that a specific watch was examined. The public pages do not describe it as a transferable token attached to the object, nor any way for a third party to verify it independently.
+## Give the buyer a concrete next step
 
-So the documented instrument answers a question of authenticity — is this watch genuine — for a named requester, at one point in time. Whether anything answers the market's question at the moment that matters most, the instant a stranger is about to pay, is not addressed in the public documentation. No public page describes a way for that stranger to verify the watch, or an existing certificate, independently. The documented routes remain the ones the warning itself names: contact the manufacture, or rely on a professional's expertise.
+Ask which document supports the claim you intend to rely on: authenticity, a particular repair, warranty coverage or the seller's authority. If a document cannot be checked, identify that gap and seek clarification before treating the claim as established.
 
-The Patrimoine service shows the manufacture understands the stakes of the secondary market better than most: it literally operates one, with restoration and a fresh warranty. But that channel covers rare, out-of-production pieces sold through its own Boutiques. Everything else — the daily flow of transactions between collectors, dealers and auction rooms — happens outside the perimeter where the manufacture's word is attached to the sale.
+## Frequently asked questions
 
-| Property | Certificate of Authenticity (today) | A portable proof |
-| --- | --- | --- |
-| Bound to | The named requester | The watch itself |
-| Who can verify | The named requester (as documented) | Anyone, at the moment of transaction |
-| Transfer at resale | Not described publicly | Yes — passes with the item |
-| Contact with manufacture per sale | Required by the documented process | Only at issuance |
-| Coverage | Watches sold over 5 years ago | Any enrolled item, any age |
-| What it proves | A past examination | A live, checkable attestation |
+### Who can request an F.P. Journe authenticity certificate?
 
-Reading guide: the left column reflects only what the manufacture's public pages document. "Not described" means exactly that — an absence from the public record, not proof that no mechanism exists.
+The manufacture's warranty FAQ says a certificate can be requested for a timepiece sold more than five years before the request. The watch must be certified by an F.P. Journe Boutique, and the document is made out to a named person.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 232" role="img" aria-label="Five properties a portable proof of authenticity must have. Bound to the item, not to a person: the proof identifies the watch, not a named requester. Verifiable by anyone: a buyer, dealer or auction house can check it without contacting the manufacture. Transferable: it passes from seller to buyer with ownership. Issued once: the manufacture signs at issuance instead of re-certifying every resale. Privacy-preserving: the proof reveals authenticity, not the owner's identity or history." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="26" fontSize="14" fontWeight="600" fill="#FFFFFF">What a portable proof must do</text>
-    <rect x="20" y="42" width="400" height="32" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="36" y="62" fontSize="11" fontWeight="600" fill="#22D3EE">1 · Bound to the item</text>
-    <text x="216" y="62" fontSize="10" fill="rgba(255, 255, 255, 0.75)">Names the watch, not a person</text>
-    <rect x="20" y="80" width="400" height="32" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="36" y="100" fontSize="11" fontWeight="600" fill="#22D3EE">2 · Verifiable by anyone</text>
-    <text x="216" y="100" fontSize="10" fill="rgba(255, 255, 255, 0.75)">No phone call to Geneva required</text>
-    <rect x="20" y="118" width="400" height="32" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="36" y="138" fontSize="11" fontWeight="600" fill="#22D3EE">3 · Transferable</text>
-    <text x="216" y="138" fontSize="10" fill="rgba(255, 255, 255, 0.75)">Passes to the buyer with ownership</text>
-    <rect x="20" y="156" width="400" height="32" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="36" y="176" fontSize="11" fontWeight="600" fill="#22D3EE">4 · Issued once</text>
-    <text x="216" y="176" fontSize="10" fill="rgba(255, 255, 255, 0.75)">Signed at birth, not per resale</text>
-    <rect x="20" y="194" width="400" height="32" rx="6" fill="rgba(0, 255, 255, 0.05)" stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
-    <text x="36" y="214" fontSize="11" fontWeight="600" fill="#22D3EE">5 · Privacy-preserving</text>
-    <text x="216" y="214" fontSize="10" fill="rgba(255, 255, 255, 0.75)">Reveals authenticity, not the owner</text>
-  </svg>
-</div>
+### Does a nominative certificate require a new examination at every resale?
 
-## The limits of what we know
+That conclusion does not follow from the word nominative. Ask the manufacture how an existing certificate can be checked and what applies to the proposed transaction. Its public description does not settle every resale situation.
 
-Intellectual honesty about this file.
+### What is the Patrimoine service?
 
-- **No number.** A count of flagged items circulates in secondary coverage. We publish none: no dated, archivable statement from the manufacture fixes a count, and the verifiable artefact is the warning banner itself, archived 30 August 2026.
-- **Where the warning first appeared is unconfirmed.** luxe.net attributes it to social networks while acknowledging it could not access the brand's channels. We found no archivable social post; the warning is live on the official site, which is what we cite.
-- **WatchPro's article could not be re-read in full.** Its site blocks automated access; we confirmed the title and 28 August 2026 date via Google News, nothing more.
-- **The certificate's price and turnaround are not public.** Neither the service page nor the FAQ states a fee or a delay; we do not speculate.
-- **We do not know the scale of the problem.** The banner proves the manufacture considers fakes a live threat to its collectors; it says nothing about volumes in circulation, and we do not use market-price data as evidence of authenticity risk.
+F.P. Journe describes Patrimoine, created in 2016, as its channel for buying back rare watches no longer in production, restoring them and reselling them through its boutiques with a three-year sales warranty.
 
-## Galileo's take
-
-**Galileo's take: F.P. Journe is doing everything an independent manufacture can do within the paper perimeter — and the perimeter is the story.** A warning popup, a nominative certificate, a buyback-and-restore channel with a fresh warranty: each instrument is serious, and each stops at the same boundary. The manufacture's word exists, but no public page describes it travelling with the watch. On the documented record, every private resale re-opens the question — and the route to a fresh answer runs through a Boutique. That is not a criticism of F.P. Journe, whose Patrimoine service is arguably the most honest institutional reading of its own secondary market. It is the precise shape of the missing layer: item-level identity, signed once by the manufacture, verifiable by anyone, transferable with the watch, silent about who holds it. That is the layer Galileo Protocol builds — verifiable digital twins and interoperable attestations, with personal data off-chain and schemas published openly in our [specifications](/specifications). Explore the [documentation](/docs) or [contact us](mailto:info@galileoprotocol.io).
-
-## Sources
-
-- [F.P. Journe, official homepage](https://www.fpjourne.com/en): anti-counterfeit warning popup ("all of these watches, clocks and related products are counterfeits… contact us before purchasing… Do not purchase without the expertise of a professional"), with photographs of flagged clocks, accessories and watches each stamped "FAKE". Accessed directly and archived (screenshot and HTML) 30 August 2026.
-- [F.P. Journe, Service page](https://www.fpjourne.com/fr/service): ten-step service process and the "CERTIFICAT D'AUTHENTICITÉ" block routing requests to Boutiques. Consulted 30 August 2026.
-- [F.P. Journe, Warranty FAQ](https://www.fpjourne.com/fr/garantie): certificate regime (Boutique certification, timepieces sold more than five years ago, nominative document); buying from the official network to avoid counterfeits and stolen watches. Consulted 30 August 2026.
-- [F.P. Journe, Patrimoine](https://www.fpjourne.com/fr/patrimoine) and [Patrimoine inventory](https://www.fpjourne.com/fr/patrimoine-le-bilan): service created in 2016, buyback of rare out-of-production watches, Manufacture restoration, resale through Boutiques with a new three-year sales warranty. Consulted 30 August 2026.
-- [F.P. Journe, press area](https://www.fpjourne.com/en/press-area): no dedicated anti-counterfeit dossier visible. Consulted 30 August 2026.
-- [WatchPro USA, "Beware of super-fakes warns F.P. Journe"](https://usa.watchpro.com/beware-of-super-fakes-warns-f-p-journe/), 28 August 2026: first trade-press coverage; title and date confirmed via Google News, full text behind a bot wall. Consulted 30 August 2026.
-- [luxe.net, "F.P. Journe écrit directement à ses collectionneurs face à la multiplication des contrefaçons"](https://luxe.net/f-p-journe-contrefacon-collectionneurs/), 29 August 2026: attributes the warning to social networks, itself flags it could not access the brand's site or accounts directly. Consulted 30 August 2026.
-
-## FAQ
-
-### Did F.P. Journe really publish an anti-counterfeit warning?
-
-Yes, on its own official website. As of 30 August 2026, the homepage of [fpjourne.com](https://www.fpjourne.com/en) opens a warning popup. It states that the watches, clocks and related products shown are counterfeits, and advises collectors to exercise the utmost vigilance and contact the manufacture before purchasing. A count of flagged items circulates in secondary coverage, but no dated, archivable statement from the manufacture fixes a number. We rely only on the banner displayed on the official site.
-
-### What is the F.P. Journe Certificate of Authenticity?
-
-According to the manufacture's [warranty FAQ](https://www.fpjourne.com/fr/garantie), a certificate of authenticity can be issued for any timepiece sold more than five years before the request. The watch must be certified by an F.P. Journe Boutique, and the document is established on a nominative basis — made out to a named person. The [service page](https://www.fpjourne.com/fr/service) routes requests through the Boutiques: "Nous vous invitons à contacter une Boutique F.P.Journe."
-
-### Is the F.P. Journe certificate transferable when the watch is resold?
-
-The public documentation does not say. The certificate is nominative: it attests, for a named requester, that a specific watch was examined and certified by the manufacture. The manufacture's public pages describe no transfer mechanism at resale, and no way for a buyer to verify a certificate independently at the moment of the transaction. That is a documentation gap, not proof that no mechanism exists.
-
-### What is the F.P. Journe Patrimoine service?
-
-Created in 2016, the [Patrimoine service](https://www.fpjourne.com/fr/patrimoine) is the manufacture's own secondary-market channel. F.P. Journe buys back rare watches in good condition that are no longer in production. It restores case and movement to their original state, and resells them on request through its Boutiques with a new three-year sales warranty.
-
-### What would a portable proof change for the secondary market?
-
-Verification would travel with the watch. A buyer, dealer or auction house could check item-level authenticity at the moment of the transaction, without routing through the manufacture. The proof would pass from seller to buyer with ownership. The manufacture's authority would be exercised once, at issuance, instead of being re-invoked for every resale.
+The [Galileo documentation](/docs) explains product-record concepts, and our [revocation guide](/blog/2026-09-05-product-passport-revocation-resale) covers what to do when a digital attestation is no longer reliable.

--- a/website/content/blog/2026-08-30-fpjourne-secondary-market-portable-proof.mdx
+++ b/website/content/blog/2026-08-30-fpjourne-secondary-market-portable-proof.mdx
@@ -47,7 +47,7 @@ The [official warranty FAQ](https://www.fpjourne.com/fr/garantie), consulted on 
 
 That five-year condition concerns when a certificate may be requested. It is not a general five-year warranty for every watch.
 
-The [Patrimoine page](https://www.fpjourne.com/fr/patrimoine) describes a programme created in 2016 for rare watches no longer in production. The manufacture buys back eligible pieces, restores them and offers them through its boutiques with a new three-year sales warranty.
+The [Patrimoine page](https://www.fpjourne.com/fr/patrimoine) describes a programme created in 2016 for rare watches no longer in production. The manufacture buys back eligible pieces and offers them through its boutiques with a new three-year sales warranty. Its [institutional brochure](https://www.fpjourne.com/sites/default/files/2026-01/DP_Institutionnel_ANG_2025.pdf) also explains that Patrimoine watches are restored before resale.
 
 These are documented routes to manufacturer involvement. The conditions of a particular purchase or service still need to be checked with the relevant boutique.
 

--- a/website/content/blog/2026-08-31-rwa-tokenization-leaves-finance-luxury-physical-assets.mdx
+++ b/website/content/blog/2026-08-31-rwa-tokenization-leaves-finance-luxury-physical-assets.mdx
@@ -1,10 +1,14 @@
 ---
-title: "From T-Bills to Handbags: Tokenization Leaves Finance"
-date: "2026-08-31"
-modified: "2026-09-04"
-author: "Pierre Beunardeau"
-excerpt: "On 3 September 2026 Beezie and The Luxury Closet announced Solana tokens for authenticated pre-owned luxury. Coinbase had already put US equities on Base. A token, a vault, a reseller check and a maison proof are four layers. Hermès is not a party to the deal."
-description: "Beezie and The Luxury Closet announced Solana tokens for resale luxury on 3 September 2026. Token, vault, reseller check and maison proof are distinct."
+title: 'From Shares to Handbags: What a Token Really Gives You'
+date: '2026-08-31'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  Compare tokenized shares with Beezie's announced luxury marketplace. Check the
+  holder's rights, stored item, redemption terms and authentication.
+description: >-
+  Compare tokenized shares with Beezie's announced luxury marketplace. Check the
+  holder's rights, stored item, redemption terms and authentication.
 tags:
   - rwa
   - tokenization
@@ -12,212 +16,77 @@ tags:
   - provenance
   - regulation
 published: true
-coverImage: "/images/blog/rwa-tokenization-leaves-finance-luxury-physical-assets.jpg"
-coverImageAlt: "A black leather luxury handbag on a dark obsidian surface, a translucent cyan holographic coin dissolving into luminous particles that flow toward the bag, tech-noir editorial illustration"
+coverImage: /images/blog/rwa-tokenization-leaves-finance-luxury-physical-assets.jpg
+coverImageAlt: A black handbag beside an illustrated cyan ring dissolving into particles
 faq:
-  - question: "Did Coinbase really put US stocks on a blockchain?"
-    answer: "Yes. On 24 August 2026, Coinbase launched Tokenized Stocks on its Base network for eligible users outside the United States. The tokens — NVDAc, METAc, AAPLc, GOOGLc and others — are real equity securities issued under Base's B20 standard. Each is backed 1:1 by a share held in regulated custody with Alpaca under the Abu Dhabi Global Market framework. Chainlink supplies the official price feeds that let DeFi protocols accept them as collateral."
-  - question: "How large had the tokenized RWA market become by mid-2026?"
-    answer: "No single end-of-August total is used here because live dashboards are dynamic and methodologies differ. Reproducible dated benchmarks put the market in the same range. a16z crypto reported more than $30 billion on 8 May and near $34 billion excluding stablecoins on 22 May. The Stobox mid-year report counted $33.5 billion excluding stablecoins on 10 July. These figures establish the scale without pretending to a live point estimate."
-  - question: "Is a tokenized stock the same thing as a tokenized handbag?"
-    answer: "No, and the distinction is regulatory before it is technical. A tokenized stock is a financial instrument because of the rights it carries: in the EU it lives under securities law, MiFID II, with KYC, custody and prospectus duties. The DLT Pilot Regime is an authorization-based framework for DLT market infrastructures, not an automatic rulebook. A token linked to a physical luxury good is product data: authenticity, provenance, ownership. That layer is governed by the ESPR's Digital Product Passport framework, not by securities law. Mixing the two rulebooks is the classic tokenization mistake."
-  - question: "Is anyone in luxury already tokenizing physical products?"
-    answer: "Yes, on two different models. Maisons and their consortia ship brand-operated passports (Aura with LVMH maisons and Tod's; Renoon QR layers). Separately, on 3 September 2026 Beezie and The Luxury Closet announced Solana tokens for authenticated pre-owned goods. That is a reseller token with third-party authentication and vault custody. It is not a manufacturer-issued proof, and Hermès is not a party to the announcement."
-  - question: "Did Hermès partner with Beezie on 3 September 2026?"
-    answer: "No source published that day names Hermès as a contracting party. The joint Beezie and The Luxury Closet release lists an Hermès Birkin 40 among celebration inventory: a pre-owned item to be sourced and vetted by The Luxury Closet, then tokenized. Naming a bag is not a maison partnership."
-  - question: "Does a Solana token prove a bag is genuine from the maison?"
-    answer: "No. A token records an on-chain claim. Custody is where the object sits. Third-party authentication is The Luxury Closet's in-house check, as the companies describe it. Manufacturer-issued proof would be a signature from the maison itself. The 3 September announcement establishes the first three layers as their own stack. It does not establish the fourth."
-  - question: "What would tokenization change for a physical luxury good?"
-    answer: "It would make the proof portable. Item-level identity signed once by the maison, verifiable by anyone at the moment of a transaction, transferable to the buyer with ownership, and silent about who holds it. Authenticity and provenance would travel with the watch or the bag instead of being re-established through the brand at every resale."
+  - question: Was Beezie's luxury activation already launched on 3 September?
+    answer: >-
+      The 3 September 2026 release announced the partnership and described the
+      luxury activation as launching in late 2026. An announcement is not
+      evidence that the complete service was already operating.
+  - question: Does a quoted swap value of up to 92% guarantee a minimum return?
+    answer: >-
+      No. Beezie's release refers to up to 92% of fair market value. That is not
+      a guaranteed minimum or a promise to recover 92% of the purchase price.
+      The valuation and applicable terms need checking.
+  - question: Does one B20 token always equal one underlying share?
+    answer: >-
+      No. Base's documentation says to apply the current multiplier when
+      converting token units to underlying shares. Corporate actions can change
+      that relationship without changing the raw token balance.
 ---
+A token can represent rights in a financial asset or rights connected to a stored physical item. Before buying, establish exactly what the holder can claim, who must fulfil it and how the underlying asset is checked.
 
-The last week of August 2026 settled one question: tokenization works for finance, at scale, under regulated custody. On 3 September 2026, Beezie and The Luxury Closet put authenticated pre-owned luxury on Solana as tokens, which is not a manufacturer-issued proof.
+Recent tokenized-share services and Beezie's announced luxury marketplace illustrate different arrangements. They should not be treated as interchangeable because both use a blockchain.
 
-On 24 August, Coinbase put US equities on its Base blockchain, after dated May and July benchmarks had placed the tokenized real-world asset market above $30 billion. What that week did not settle is the other half of the story: the physical object. The watch, the handbag, the piece of jewelry: assets whose value events are not dividends but authenticity, provenance and resale. That is where tokenization has yet to leave finance.
+**Updated 12 September 2026:** this article retains its original August publication date and includes the Beezie partnership announced on 3 September.
 
-This is an analysis, not a news dispatch. The Coinbase hook is a week old, and the pattern it reveals will outlive the week.
+## What Beezie and The Luxury Closet announced
 
-*Update of 4 September 2026: Beezie and The Luxury Closet announced a Solana listing for authenticated pre-owned luxury on 3 September. The case is integrated below. It does not change the finance milestone of 24 August, and no published source that day names Hermès as a party to the deal.*
+The [3 September 2026 release issued by Beezie](https://www.globenewswire.com/news-release/2026/09/03/3355924/0/en/beezie-and-the-luxury-closet-launch-on-chain-marketplace-for-authenticated-luxury-goods.html) describes luxury goods sourced and checked by The Luxury Closet, represented on Solana and held in vault storage. It schedules the luxury activation for **late 2026**, initially through blind shopping bags whose contents are revealed after opening.
 
-## The week tokenization put stocks on-chain
+The release mentions swaps for **up to 92% of fair market value**. This is not a guaranteed minimum, nor a promise to recover that percentage of the original purchase price. A participant would need the valuation method, fees, eligibility and terms before relying on a proposed exit value.
 
-On Monday 24 August 2026, [Coinbase launched Tokenized Stocks on Base](https://www.nasdaq.com/press-release/coinbase-selects-chainlink-bring-new-tokenized-stocks-millions-defi-users-2026-08-24), for eligible users outside the United States. The structure deserves a careful read. It is the most regulated version of tokenization yet shipped by a major exchange.
+These are the companies' announced plans and service claims. Naming designer items in the inventory does not establish that their manufacturers participate in the partnership.
 
-- **Real securities, not derivatives.** Each token — NVDAc, METAc, AAPLc, GOOGLc and others — is backed 1:1 by an underlying share. The holder has a direct claim on that share.
-- **Regulated custody.** Shares sit with Alpaca, a regulated broker-custodian, in a bankruptcy-remote structure under the Abu Dhabi Global Market (ADGM) framework.
-- **A purpose-built standard.** The tokens are issued under [B20, Base's native token standard](https://docs.base.org/base-chain/specs/reference/b20/tokenized-stocks-on-base) — an ERC-20 extension designed for real-world assets, with corporate-action multipliers, allowlist and blocklist policies, and KYC enforced at mint and redeem by authorized participants. Secondary trading itself is permissionless.
-- **Institutional market data.** Chainlink is the official oracle, streaming continuous pricing so DeFi lending markets and exchanges can treat the tokens as composable collateral.
+## A tokenized share has a different underlying claim
 
-Within days, coverage framed the launch as the convergence of traditional markets and on-chain finance. Galaxy Research noted the asymmetry on 28 August: [the tokens are live; the SEC's framework for them is not](https://www.galaxy.com/insights/research/coinbase-tokenized-stocks-base-third-party-issuer-sec-innovation-exemption) — one reason the product is unavailable to US users. The launch also landed in a risk-on market: [bitcoin crossed $80,000 on 25 August 2026](https://finance.yahoo.com/personal-finance/investing/article/bitcoin-and-ethereum-prices-today-tuesday-august-25-2026-highest-opening-for-bitcoin-in-over-three-months-123338376.html), a three-month high.
+[Coinbase's Tokenize page](https://www.coinbase.com/tokenize), consulted on 12 September, describes its tokenized stocks as beneficial claims backed by underlying shares in custody. That arrangement is different from receiving the physical asset in a luxury redemption.
 
-None of this is hype. It is the financial half of tokenization reaching production grade.
+Coinbase limits availability by jurisdiction and reserves primary creation and redemption to onboarded institutional partners and authorised participants. A reader should not assume that being outside the United States makes every operation available to them.
 
-## A $30 billion market whose dashboard tracks only finance
+[Base's B20 documentation](https://docs.base.org/build-on-base/integrate-defi/list-tokenized-stocks) also explains a multiplier, a factor used to convert token units into the relevant underlying share quantity. Corporate actions can change it without changing the raw token balance. One token does not permanently equal one share.
 
-The numbers, each dated and attributed:
+The comparison shows why a wallet balance is only the beginning of the inquiry. Read the instrument's terms and follow the responsible parties and records, as developed in our [ownership-register guide](/blog/2026-09-06-tokenized-shares-ownership-register).
 
-- **$30 billion crossed in May.** a16z crypto documented tokenized RWAs [topping $30 billion — roughly 10x in two years](https://a16zcrypto.com/posts/article/real-world-assets-market-cap-data-chart/), with nearly half in US Treasury debt, on 8 May 2026 (data: rwa.xyz).
-- **Near $34 billion later that month.** On 22 May, [a16z crypto reported the market near $34 billion](https://a16zcrypto.com/posts/article/tokenized-asset-rwa-market-data-charts/) excluding stablecoins, while warning that published totals vary with methodology.
-- **$33.5 billion by another methodology.** The [Stobox State of RWA mid-year report](https://www.stobox.io/reports/state-of-rwa-2026) counted $33.5 billion excluding stablecoins as of 10 July 2026, across 167 platforms, with Ethereum holding 47.9% of value. As we noted when [MiCA's transitional period ended](/blog/2026-08-25-mica-transitional-period-rwa), that report carries the honest caveat: issuance is not liquidity.
-- **Tokenized equities at a record $2.3 billion** by mid-July 2026, per the Coinbase–Chainlink announcement — the category Coinbase just entered.
+## Follow a physical item from token to delivery
 
-Now look at what the sector's reference dashboard actually tracks. rwa.xyz's asset classes as of 31 August 2026: government securities, non-US government debt, private credit, stocks, commodities, real estate, private equity and venture capital, active strategies. Every category is a financial claim. **There is no luxury-goods category. There is no collectibles category.** A Google News scan of "RWA tokenization" on 31 August 2026 returns asset managers, stablecoin launches and securities platforms. The top hits: BlackRock's BUIDL, World Liberty's USD1 on Canton, Shinhan Asset Management signing with Plume. Not one physical-goods story in the first 20 results.
+Consider a fictional buyer choosing a token redeemable for one stored handbag. The buyer needs to know which bag is reserved, where it is held and what evidence supports its authenticity and condition.
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 324" role="img" aria-label="Diagram of what the RWA market dashboard tracks and what it does not. Left column, the rwa.xyz asset classes as of 31 August 2026: government securities, non-US government debt, private credit, stocks, commodities, real estate, private equity and VC, active strategies — all financial claims. Right column, dashed, the asset classes with no category in the tracker: watches, handbags, jewelry, art and collectibles — physical objects whose value events are authenticity, provenance and resale. Bottom band: no luxury-goods category exists in the tracker as of 31 August 2026." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="26" fontSize="14" fontWeight="600" fill="#FFFFFF">What the RWA dashboard tracks — and what it doesn't</text>
-    <rect x="20" y="44" width="200" height="200" rx="6" fill="#0E7490" opacity="0.35" />
-    <text x="34" y="66" fontSize="10" fontWeight="600" fill="#FFFFFF">rwa.xyz asset classes</text>
-    <text x="34" y="92" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Government securities</text>
-    <text x="34" y="114" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Non-US govt debt</text>
-    <text x="34" y="136" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Private credit</text>
-    <text x="34" y="158" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Stocks</text>
-    <text x="34" y="180" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Commodities</text>
-    <text x="34" y="202" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Real estate</text>
-    <text x="34" y="224" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· PE / VC, active strategies</text>
-    <rect x="240" y="44" width="180" height="200" rx="6" fill="none" stroke="#22D3EE" strokeWidth="1" strokeDasharray="5 4" opacity="0.8" />
-    <text x="254" y="66" fontSize="10" fontWeight="600" fill="#FFFFFF">No category for</text>
-    <text x="254" y="92" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Watches</text>
-    <text x="254" y="114" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Handbags</text>
-    <text x="254" y="136" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Jewelry</text>
-    <text x="254" y="158" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">· Art &amp; collectibles</text>
-    <text x="254" y="190" fontSize="9" fill="rgba(255, 255, 255, 0.55)">Value events: authenticity,</text>
-    <text x="254" y="203" fontSize="9" fill="rgba(255, 255, 255, 0.55)">provenance, resale —</text>
-    <text x="254" y="216" fontSize="9" fill="rgba(255, 255, 255, 0.55)">not yield</text>
-    <rect x="20" y="258" width="400" height="36" rx="6" fill="#041c30" stroke="rgba(0, 255, 255, 0.35)" strokeWidth="1" />
-    <text x="220" y="273" textAnchor="middle" fontSize="10" fontWeight="600" fill="#22D3EE">Every tracked category is a financial claim</text>
-    <text x="220" y="287" textAnchor="middle" fontSize="9" fill="rgba(255, 255, 255, 0.7)">No luxury-goods category exists in the tracker</text>
-    <text x="20" y="314" fontSize="9.5" fill="rgba(255, 255, 255, 0.55)">Source: rwa.xyz asset-class tabs, consulted 31 August 2026.</text>
-  </svg>
-</div>
+Next comes the delivery promise. Who must release the bag? What identification, fees and shipping conditions apply? What happens if the bag is damaged, the custodian fails or the record points to the wrong item?
 
-The market is real, and its map stops at the boundary of finance.
+A successful token transfer answers none of those questions by itself. It may establish a digital operation while the physical item remains in someone else's custody. Likewise, a reseller's authentication is not automatically a manufacturer-issued attestation.
 
-## Two machines, two rulebooks
+For this fictional purchase, a useful record would connect the specific item, the custodian, the assessment and the redemption obligation. Each claim should remain attributable to the party responsible for it.
 
-Why has the physical object been left behind? Part of the answer is that the two tokenizations look similar and obey different laws.
+## Classify the rights before choosing the technology
 
-**A tokenized security is a financial instrument — because of the rights it carries, not its wrapper.** Qualification comes first: a token that grants the rights of a transferable security is a security, whatever the technical standard. In the EU it then falls under securities law, [MiFID II](https://eur-lex.europa.eu/eli/dir/2014/65/oj), outside MiCA's scope — the qualification exercise we detailed when [the MiCA transitional period ended](/blog/2026-08-25-mica-transitional-period-rwa). The [DLT Pilot Regime](https://eur-lex.europa.eu/eli/reg/2022/858/oj) sits one level down: an authorization-based framework for DLT market infrastructures, not an automatic rulebook for every tokenized security. Its compliance burden is market conduct: KYC, custody, prospectus, suitability. Its technical needs are cash flows, corporate actions and price feeds. Coinbase's B20 launch is this machine, running well.
+Linking a token to a physical product does not automatically remove it from financial regulation. The rights and services require assessment; [MiCA article 2](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-2-scope) distinguishes its scope from, among other things, financial instruments.
 
-**A token bound to a physical luxury good is product data.** Its compliance burden is not securities law but the [ESPR's Digital Product Passport framework](/blog/2026-08-25-eu-dpp-registry-live): identity, composition, provenance, repairability. The framework is in force; the passport obligation phases in by product group, through delegated acts. Its value events are not dividends but authentication, condition, service history and the transfer of ownership at resale. It does not need an oracle price feed. It needs a proof a stranger can check.
+An ordinary product passport that supplies care information is not the same arrangement as a transferable investment or redemption claim. Describe the customer promise first, then identify the applicable rules and the infrastructure needed to support it.
 
-Mixing the two rulebooks is the classic industry mistake. Treat a security as a utility token and you get an enforcement action. Treat a handbag passport as a financial asset and you import a compliance machine built for the wrong problem — which is one reason maisons have moved slowly.
+## Frequently asked questions
 
-## The missing middle: physical luxury
+### Was Beezie's luxury activation already launched on 3 September?
 
-None of this means luxury is absent from tokenization — claiming a vacuum would be wrong, and our own coverage documents the exceptions. The Aura Blockchain Consortium has shipped product passports with LVMH maisons and Tod's since 2023. Tod's runs [two passport stacks on the Gommino line](/blog/2026-08-28-tods-gommino-two-passports-renoon-aura) — an Aura NFC certificate, and a Renoon QR layer live on tods.com since 28 August 2026. [LVMH has put a group-level DPP strategy in writing](/blog/2026-08-26-lvmh-dpp-strategy). Standards are maturing too: ERC-7943 reached Final status as an Ethereum RWA standard in May 2026, per the Stobox report.
+The 3 September 2026 release announced the partnership and described the luxury activation as launching in late 2026. An announcement is not evidence that the complete service was already operating.
 
-What these programmes ship are brand-operated certificates and data layers. What they do not yet ship is the portable proof — item-level identity a buyer, dealer or auction house can verify at the moment of transaction and receive with the object. The gap is visible in the most documented case of the season. F.P. Journe warns collectors on its own site and issues [a nominative Certificate of Authenticity through its Boutiques](/blog/2026-08-30-fpjourne-secondary-market-portable-proof) — but its public pages describe no proof that travels with the watch. And the regulatory wind pushes the same direction: once [destroyed volumes become public numbers under the ESPR](/blog/2026-08-29-espr-destruction-ban-luxury-disclosure), a certified, authenticated resale channel stops being marketing and starts being compliance arithmetic.
+### Does a quoted swap value of up to 92% guarantee a minimum return?
 
-That is the missing middle of tokenization. Not another Treasury fund — the object layer, where authenticity and resale create the need for proof. The ESPR sets the framework there; obligations arrive category by category, via delegated acts that do not yet cover watches or jewelry.
+No. Beezie's release refers to up to 92% of fair market value. That is not a guaranteed minimum or a promise to recover 92% of the purchase price. The valuation and applicable terms need checking.
 
-## A 3 September test: Beezie, The Luxury Closet, Solana
+### Does one B20 token always equal one underlying share?
 
-On 3 September 2026, [Beezie and The Luxury Closet issued a joint release from Boston](https://lifestyle.fictiontalk.com/story/831098/beezie-and-the-luxury-closet-launch-on-chain-marketplace-for-authenticated-luxury-goods/). The dateline is GlobeNewswire. The companies say they will put authenticated pre-owned handbags, watches, jewelry and accessories on Solana as digital twins, one token per object, with a late-2026 launch. [The Crypto Times](https://www.cryptotimes.io/2026/09/03/hermes-birkins-head-to-solana-in-beezie-luxury-closet-deal/) reported the same release the same day.
+No. Base's documentation says to apply the current multiplier when converting token units to underlying shares. Corporate actions can change that relationship without changing the raw token balance.
 
-This is the first dated physical-luxury token story in this dossier. It does not fill the missing middle. It shows why four layers must stay separate.
-
-**Token.** The release says each authenticated item is tokenized on Solana. The token is the transferable claim. A Solana transfer records that claim. It does not inspect leather, stitching or a serial.
-
-**Custody.** The same release says each item is "held in secure vault storage until it is redeemed or shipped directly to the collector." It does not name the vault operator for this activation, nor publish insurance terms, redemption fees or a shipping schedule. Beezie's [collectibles FAQ](https://docs.beezie.com/additional-information/general-faq) names Brink's as vault partner for that product. That published claim is not restated here as a fact of the luxury drop.
-
-**Third-party authentication.** Every piece, the companies say, will be "sourced and vetted by The Luxury Closet's in-house authentication team" before listing. Kunal Kapoor, CEO of The Luxury Closet, said in the release: "Through this partnership, we apply our same rigor in sourcing and authentication to onchain ownership." That is a reseller's check. It is not a maison attestation.
-
-**Manufacturer-issued proof.** The celebration inventory names an Hermès Birkin 40, a Chanel handbag, Dior and Louis Vuitton duffels, a Rolex GMT-Master II and a Van Cleef & Arpels necklace. Those are brand names on pre-owned stock. The release does not say Hermès, Chanel, Dior, Louis Vuitton, Rolex or Van Cleef signed, vaulted or sold the items. Naming a Birkin is not a partnership with Hermès.
-
-Andrea Miele, founder and CEO of Beezie, put the companies' claim this way. "Luxury has always had the characteristics of a collectible: scarcity, cultural value and a secondary market. What's been missing is the infrastructure that lets people interact with those assets as easily as they do digital ones." Infrastructure for trading a claim is not identity issued by the maker.
-
-The companies also state, as a promotional figure, that collectors can swap items back "for up to 92% of their fair market value." How that floor is calculated, funded and enforced is not published. The same release says the Claw machines have crossed "more than 1 million pulls." That count is self-declared. The release dates the launch as "late 2026" and promises published odds and an always-on catalogue of thousands of items. Those modalities are not in the 3 September text. Until listings go live, they remain unpublished.
-
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 268" role="img" aria-label="Four proof layers in the 3 September 2026 Beezie and The Luxury Closet announcement. Token: Solana digital twin, one claim per object. Custody: vault storage named in the release without an operator. Third-party authentication: The Luxury Closet in-house team. Manufacturer-issued proof: not claimed; Hermès is not a party." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="24" fontSize="13" fontWeight="600" fill="#FFFFFF">Four layers the 3 September release must not mix</text>
-    <rect x="20" y="40" width="190" height="88" rx="6" fill="#0E7490" opacity="0.35" />
-    <text x="34" y="62" fontSize="10" fontWeight="600" fill="#22D3EE">1. Token</text>
-    <text x="34" y="82" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">Solana digital twin</text>
-    <text x="34" y="98" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">One claim per object</text>
-    <text x="34" y="114" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">Transfer is not inspection</text>
-    <rect x="230" y="40" width="190" height="88" rx="6" fill="#0E7490" opacity="0.35" />
-    <text x="244" y="62" fontSize="10" fontWeight="600" fill="#22D3EE">2. Custody</text>
-    <text x="244" y="82" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">Vault storage, unnamed</text>
-    <text x="244" y="98" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">operator in this release</text>
-    <text x="244" y="114" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">Fees and insurance unpublished</text>
-    <rect x="20" y="140" width="190" height="88" rx="6" fill="#0E7490" opacity="0.35" />
-    <text x="34" y="162" fontSize="10" fontWeight="600" fill="#22D3EE">3. Third-party check</text>
-    <text x="34" y="182" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">The Luxury Closet</text>
-    <text x="34" y="198" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">in-house authentication</text>
-    <text x="34" y="214" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">A reseller check, not a maison</text>
-    <rect x="230" y="140" width="190" height="88" rx="6" fill="none" stroke="#22D3EE" strokeWidth="1" strokeDasharray="5 4" opacity="0.85" />
-    <text x="244" y="162" fontSize="10" fontWeight="600" fill="#22D3EE">4. Maison proof</text>
-    <text x="244" y="182" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">Not claimed on 3 Sept</text>
-    <text x="244" y="198" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">Hermès is not a party</text>
-    <text x="244" y="214" fontSize="9.5" fill="rgba(255, 255, 255, 0.75)">A Birkin name is inventory</text>
-    <text x="20" y="252" fontSize="9.5" fill="rgba(255, 255, 255, 0.55)">Source: Beezie / The Luxury Closet GlobeNewswire release, 3 September 2026.</text>
-  </svg>
-</div>
-
-A transaction on Solana can move the token. It cannot, by itself, establish that Hermès issued the bag.
-
-## The limits of what we know
-
-Intellectual honesty about this analysis.
-
-- **The $30 billion crossing is not this week's event.** a16z documented it on 8 May 2026. This week's milestone is the Coinbase launch.
-- **Methodologies diverge.** a16z reported the market near $34 billion excluding stablecoins on 22 May; Stobox counted $33.5 billion on 10 July. We deliberately publish no exact 31 August total: live dashboard point estimates are dynamic and cannot be independently reproduced after the fact.
-- **"Every headline was finance" is a snapshot.** It reflects one Google News query — 20 results scanned, archived — on 31 August 2026, not a systematic media study.
-- **The dashboard can change.** The absence of a luxury category on rwa.xyz is an observation as of 31 August 2026, not a permanent state.
-- **B20's reach is unproven.** It is a Base-native standard today; whether it travels beyond Base is an open question we do not speculate on.
-- **Adoption is unknown.** Coinbase publishes no usage figures one week after launch, and the product remains unavailable to US users.
-- **The 3 September luxury figures are self-declared.** "Up to 92% of their fair market value" and "more than 1 million pulls" come from the companies' own release. They are not independently audited here.
-- **Launch modalities are unpublished.** The release does not give a calendar day, a redemption-fee schedule, insurance terms, luxury-drop odds, or the vault operator for this activation.
-- **Hermès is not documented as a partner.** The Birkin 40 is named as inventory. No maison statement confirming the listing was found on 4 September 2026.
-
-## Galileo's take
-
-**Galileo's take: the financial half of tokenization just reached production grade — and that is precisely when the object half becomes visible.** When equities settle on-chain under ADGM custody with institutional oracles, "can we tokenize it?" stops being the question. The question becomes which assets still lack their proof layer. The 3 September Beezie case is the object layer arriving as a reseller token: useful as a dated test, insufficient as manufacturer-issued identity. Physical luxury remains the largest gap: high-value objects, a structured secondary market, counterfeiting pressure manufactures themselves flag publicly, and a regulator phasing in passport obligations category by category. The object does not need a price feed or a corporate-action multiplier. It needs identity signed once by the maison, verifiable by anyone, transferable with the item, silent about who holds it. Personal data stays off-chain, with schemas published openly in our [specifications](/specifications). That is the layer Galileo Protocol builds. Explore the [documentation](/docs) or [contact us](mailto:info@galileoprotocol.io).
-
-## Sources
-
-- [Chainlink / Coinbase press release, "Coinbase Selects Chainlink to Bring New Tokenized Stocks to Millions of DeFi Users"](https://www.nasdaq.com/press-release/coinbase-selects-chainlink-bring-new-tokenized-stocks-millions-defi-users-2026-08-24), 24 August 2026: B20 tokens on Base, 1:1 backing, Alpaca custody under ADGM, Chainlink as official oracle, NVDAc/METAc/AAPLc/GOOGLc, tokenized equities at a record $2.3 billion by mid-July 2026, non-US availability. Consulted 31 August 2026.
-- [Base documentation, "Tokenized Stocks on Base"](https://docs.base.org/base-chain/specs/reference/b20/tokenized-stocks-on-base): B20 as a Base-native ERC-20 extension, corporate-action multipliers, allow/blocklist policies, KYC at mint/redeem by authorized participants, permissionless secondary trading. Consulted 31 August 2026.
-- [a16z crypto, "Tokenized RWAs top $30B"](https://a16zcrypto.com/posts/article/real-world-assets-market-cap-data-chart/), 8 May 2026: $30 billion crossed, ~10x in two years, nearly half in US Treasury debt (data: rwa.xyz).
-- [a16z crypto, "Tokenized assets: The charts and numbers that matter"](https://a16zcrypto.com/posts/article/tokenized-asset-rwa-market-data-charts/), 22 May 2026: market near $34 billion excluding stablecoins and an explanation of why market totals vary by methodology.
-- [Stobox, "State of RWA Tokenization — 2026 Mid-Year Report"](https://www.stobox.io/reports/state-of-rwa-2026): $33.5 billion excluding stablecoins as of 10 July 2026, 167 platforms, Ethereum at 47.9%, ERC-7943 Final in May 2026.
-- [rwa.xyz dashboard](https://rwa.xyz): asset-class taxonomy only; no live point-in-time total is used in this article. Category observation captured 31 August 2026.
-- [Galaxy Research, "Coinbase Enters Tokenized Stock Fray on Third-Party 'Wrapper' Side"](https://www.galaxy.com/insights/research/coinbase-tokenized-stocks-base-third-party-issuer-sec-innovation-exemption), 28 August 2026: the tokens are live, the SEC framework is not.
-- [Yahoo Finance, "Bitcoin and ethereum prices today, Tuesday, August 25, 2026"](https://finance.yahoo.com/personal-finance/investing/article/bitcoin-and-ethereum-prices-today-tuesday-august-25-2026-highest-opening-for-bitcoin-in-over-three-months-123338376.html): bitcoin crossed $80,000 intraday (high $81,023.41), a three-month high. Consulted 31 August 2026.
-- Google News RSS scan, query "RWA tokenization" (hl=en-US, gl=US), 31 August 2026: first 20 results all financial (BlackRock BUIDL, World Liberty USD1 on Canton, Shinhan × Plume, Stellar, Tether real estate); method and full list archived in blogidea.md.
-- [MiFID II — Directive 2014/65/EU](https://eur-lex.europa.eu/eli/dir/2014/65/oj) and [DLT Pilot Regime — Regulation (EU) 2022/858](https://eur-lex.europa.eu/eli/reg/2022/858/oj): the EU rulebooks for tokenized financial instruments.
-- GlobeNewswire dateline BOSTON, Sept. 03, 2026, [Beezie and The Luxury Closet Launch On-Chain Marketplace for Authenticated Luxury Goods](https://lifestyle.fictiontalk.com/story/831098/beezie-and-the-luxury-closet-launch-on-chain-marketplace-for-authenticated-luxury-goods/): Solana digital twins, The Luxury Closet in-house authentication, vault storage, late-2026 launch, self-declared swap of up to 92% of fair market value, Birkin 40 named as inventory. Consulted 4 September 2026. Quoted remarks by Andrea Miele and Kunal Kapoor archived in `website/content/reviews/2026-08-31-rwa-tokenization-leaves-finance-luxury-physical-assets/citations.md`.
-- [The Crypto Times, "Hermès Birkins Head to Solana in Beezie, Luxury Closet Deal"](https://www.cryptotimes.io/2026/09/03/hermes-birkins-head-to-solana-in-beezie-luxury-closet-deal/), 3 September 2026: independent rewrite of the Boston joint release; Hermès not named as a party; redemption fees, insurance and a specific go-live date unpublished.
-- [Beezie docs, General FAQ, vault security](https://docs.beezie.com/additional-information/general-faq): Brink's named as vault partner for Beezie's collectibles product. Consulted 4 September 2026. Not used as proof of the luxury-activation operator.
-
-## FAQ
-
-### Did Coinbase really put US stocks on a blockchain?
-
-Yes. On 24 August 2026, [Coinbase launched Tokenized Stocks on Base](https://www.nasdaq.com/press-release/coinbase-selects-chainlink-bring-new-tokenized-stocks-millions-defi-users-2026-08-24) for eligible users outside the United States. The tokens — NVDAc, METAc, AAPLc, GOOGLc and others — are real equity securities issued under Base's B20 standard. Each is backed 1:1 by a share held in regulated custody with Alpaca under the Abu Dhabi Global Market framework. Chainlink supplies the official price feeds that let DeFi protocols accept them as collateral.
-
-### How large had the tokenized RWA market become by mid-2026?
-
-No single end-of-August total is used here because live dashboards are dynamic and methodologies differ. Reproducible dated benchmarks put the market in the same range. [a16z crypto](https://a16zcrypto.com/posts/article/real-world-assets-market-cap-data-chart/) reported more than $30 billion on 8 May and [near $34 billion excluding stablecoins](https://a16zcrypto.com/posts/article/tokenized-asset-rwa-market-data-charts/) on 22 May. The [Stobox mid-year report](https://www.stobox.io/reports/state-of-rwa-2026) counted $33.5 billion excluding stablecoins on 10 July. These figures establish the scale without pretending to a live point estimate.
-
-### Is a tokenized stock the same thing as a tokenized handbag?
-
-No, and the distinction is regulatory before it is technical. A tokenized stock is a financial instrument because of the rights it carries: in the EU it lives under securities law, [MiFID II](https://eur-lex.europa.eu/eli/dir/2014/65/oj), with KYC, custody and prospectus duties. The [DLT Pilot Regime](https://eur-lex.europa.eu/eli/reg/2022/858/oj) is an authorization-based framework for DLT market infrastructures, not an automatic rulebook. A token linked to a physical luxury good is product data: authenticity, provenance, ownership. That layer is governed by the [ESPR's Digital Product Passport framework](/blog/2026-08-25-eu-dpp-registry-live), not by securities law. Mixing the two rulebooks is the classic tokenization mistake.
-
-### Is anyone in luxury already tokenizing physical products?
-
-Yes. The Aura Blockchain Consortium has shipped product passports with LVMH maisons and Tod's since 2023, and Renoon builds QR-based passport data layers. Tod's even runs [two passport stacks on the Gommino line](/blog/2026-08-28-tods-gommino-two-passports-renoon-aura). These are brand-operated certificates and data stacks, not yet proofs a buyer can verify independently and receive with the object at resale. Separately, on 3 September 2026 [Beezie and The Luxury Closet](https://lifestyle.fictiontalk.com/story/831098/beezie-and-the-luxury-closet-launch-on-chain-marketplace-for-authenticated-luxury-goods/) announced Solana tokens for authenticated pre-owned goods: a reseller token with third-party authentication and vault custody, not a manufacturer-issued proof.
-
-### Did Hermès partner with Beezie on 3 September 2026?
-
-No source published that day names Hermès as a contracting party. The joint Beezie and The Luxury Closet release lists an Hermès Birkin 40 among celebration inventory: a pre-owned item to be sourced and vetted by The Luxury Closet, then tokenized. Naming a bag is not a maison partnership.
-
-### Does a Solana token prove a bag is genuine from the maison?
-
-No. A token records an on-chain claim. Custody is where the object sits. Third-party authentication is The Luxury Closet's in-house check, as the companies describe it. Manufacturer-issued proof would be a signature from the maison itself. The 3 September announcement establishes the first three layers as their own stack. It does not establish the fourth.
-
-### What would tokenization change for a physical luxury good?
-
-It would make the proof portable. Item-level identity signed once by the maison, verifiable by anyone at the moment of a transaction, transferable to the buyer with ownership, and silent about who holds it. Authenticity and provenance would travel with the watch or the bag instead of being re-established through the brand at every resale — the gap we documented in the [F.P. Journe certificate analysis](/blog/2026-08-30-fpjourne-secondary-market-portable-proof).
+Use the [Galileo documentation](/docs) to explore product identity and records while keeping custody, legal rights and physical assessment explicit.

--- a/website/content/blog/2026-09-02-chanel-serial-code-not-identity.mdx
+++ b/website/content/blog/2026-09-02-chanel-serial-code-not-identity.mdx
@@ -1,10 +1,14 @@
 ---
-title: "One Chanel Serial Number, 127 Reports, 36 Countries"
-date: "2026-09-02"
-modified: "2026-09-02"
-author: "Pierre Beunardeau"
-excerpt: "A Chanel serial code appeared 127 times in a reseller database. The case shows why a copied identifier cannot prove which physical bag is genuine."
-description: "A Chanel serial code appeared 127 times in a reseller database. The case shows why a copied identifier cannot prove which physical bag is genuine."
+title: 'Chanel Serial Codes: What 127 Reseller Reports Mean'
+date: '2026-09-02'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  A reseller reports 127 appearances of one Chanel serial code. Learn why a
+  matching number is a warning signal, not proof about the bag in front of you.
+description: >-
+  A reseller reports 127 appearances of one Chanel serial code. Learn why a
+  matching number is a warning signal, not proof about the bag in front of you.
 tags:
   - counterfeiting
   - authentication
@@ -12,282 +16,77 @@ tags:
   - luxury
   - dpp
 published: true
-coverImage: "/images/blog/chanel-serial-code-not-identity.jpg"
-coverImageAlt: "A generic black quilted luxury handbag surrounded by duplicate translucent identity tags under cyan inspection light"
+coverImage: /images/blog/chanel-serial-code-not-identity.jpg
+coverImageAlt: >-
+  A generic black quilted luxury handbag surrounded by duplicate translucent
+  identity tags under cyan inspection light
 faq:
-  - question: "Does Chanel serial number 10218184 prove that a bag is fake?"
-    answer: "No. Luxury Evermore reports seeing that code 127 times in submissions from 36 countries, which makes it a warning signal. The public database does not expose the underlying submissions for independent review. A copied code also cannot identify which physical bag, if any, received it legitimately. The bag, its construction, its provenance and the seller must still be examined."
-  - question: "Can Chanel authenticate a pre-owned handbag?"
-    answer: "Chanel's United States fashion FAQ says product authentication is not a service the house offers. It says authenticity is guaranteed only for products bought from a Chanel boutique or an authorised retailer. That leaves a secondary-market buyer relying on seller evidence, specialist examination and any product record made available by the issuer."
-  - question: "Is a microchip stronger than a printed serial number?"
-    answer: "It can be, but only if the chip does more than reveal a static value. A static NFC response can be copied or relayed. A stronger design uses a chip that proves possession of a secret through a changing cryptographic challenge, then binds that chip to the bag so it cannot be transplanted without detection."
-  - question: "Does the EU Digital Product Passport require one unique identity per luxury bag?"
-    answer: "Not automatically. Article 9 of the ESPR says a delegated act must decide whether a passport applies at model, batch or item level. Articles 10 to 12 establish the data-carrier and identifier architecture. A future product rule could require item-level granularity, but the framework itself does not yet impose that level on every handbag."
-  - question: "What should a reseller verify before accepting a luxury bag?"
-    answer: "Treat the visible code as a search key, not a verdict. Check whether it matches the product family and production period, search for reuse, inspect the physical object, verify seller and transaction evidence, and record who performed each check. If an issuer-signed item record exists, verify its signature, status and physical binding rather than trusting the scan screen alone."
+  - question: Does serial code 10218184 prove that a bag is counterfeit?
+    answer: >-
+      No. Luxury Evermore reports repeated use of the code, but its public
+      database does not expose the underlying submissions. A copied identifier
+      cannot determine which physical bag, if any, originally received it.
+  - question: Does Chanel offer an authentication service for resale purchases?
+    answer: >-
+      Chanel's United States fashion FAQ says authentication is not a service it
+      offers. It limits its authenticity guarantee to purchases from its
+      boutiques and listed authorised retailers.
+  - question: Does a conforming GS1 Digital Link prove authenticity?
+    answer: >-
+      No. The standard provides a way to express identifiers in web addresses.
+      The address alone does not prove the truth of the information reached, the
+      issuer's identity or the physical item's authenticity.
 ---
+A matching Chanel serial number cannot, by itself, authenticate the bag in front of a buyer. Luxury Evermore's reports of repeated use of one code illustrate the problem: an identifier can be copied while the physical objects differ.
 
-The number **10218184** was reported **127 times in submissions from 36 countries**, according to a reseller's public database. That repetition is a powerful warning signal, but the code alone cannot prove which physical bag is genuine.
+## What the reseller's record says
 
-This distinction matters wherever a valuable object is sold by someone other than its maker. A serial number can help find a record. It is not, by itself, evidence that the object carrying it is the object named in that record.
+The [Luxury Evermore summary database](https://luxuryevermore.com/pages/chanel-counterfeit-bags-red-flag-serial-numbers-database), marked **updated 21 August 2026** and checked again on 12 September, lists **127 occurrences across 36 countries** for code 10218184.
 
-## What the 127 reports and 36 countries actually show
+Its [detail page](https://luxuryevermore.com/pages/red-flag-chanel-datecode-serial-number-10218184) lists 35 countries, omitting Belgium from the summary list. These are the publisher's counts. The underlying submissions are not public, so neither the sample nor its geographical coverage has been independently reconstructed here.
 
-Singapore reseller Luxury Evermore maintains a public [red-flag Chanel serial-number database](https://luxuryevermore.com/pages/chanel-counterfeit-bags-red-flag-serial-numbers-database). The page, marked **last updated 21 August 2026**, gives code 10218184 a count of **127**. Its country field names **36 countries**, from Australia and Austria to the United States and Vietnam.
+The repeated code is a warning signal in the reseller's account. It does not establish which individual bag, if any, originally received that number. Nor does the database's description of an original model become an official Chanel catalogue entry merely because it appears beside the code.
 
-The company says these observations came through its free authentication review service. [Inside Retail Asia reported the finding](https://insideretail.asia/2026/08/25/chanel-scam-luxury-reseller-calls-out-widely-reused-serial-code/) on 25 August 2026. The report says the code appeared on several bag designs among submissions to that service.
+## What an identification number does
 
-Mingchuan Tian, founder of Luxury Evermore, described the marker's operational value to Inside Retail that day. He said: **“For us as resellers and authenticators, the serial number tag or microchip serves another important purpose: Helping us identify whether a product may be counterfeit.”** This is an authenticator's interpretation, not independent proof of the 127 submissions.
+A serial number helps refer to a particular record or item within the issuer's system. Reading the number is not the same as establishing who placed it on an object.
 
-The database is useful, but its evidential boundary must be visible. Luxury Evermore does not publish the 127 case files, photographs, submission dates, chain of custody or authentication outcomes. An outside reader therefore cannot reproduce the count or determine how many distinct physical bags were involved.
+An [older official Chanel care document](https://services.chanel.com/media/files/en_GB_Care_instructions_for_Bags.pdf), which has no publication date shown, describes the identification card and matching number inside a bag. It explains that historical mechanism; it should not be treated as a description of every current product.
 
-There is also a live inconsistency inside the publisher's own record. The summary table lists **36 countries** and includes Belgium. The [detail page for 10218184](https://luxuryevermore.com/pages/red-flag-chanel-datecode-serial-number-10218184) lists the countries again, but omits Belgium, leaving **35**. This article preserves the headline figure because it is the database publisher's current summary claim. It also records the mismatch rather than silently reconciling it.
+Chanel's [current US fashion FAQ](https://www.chanel.com/us/faq/fashion/) sets a separate boundary: the house does not offer an authentication service and limits its authenticity guarantee to purchases from its boutiques and listed authorised retailers.
 
-The detail page says the legitimate reference behind the code would be a black lambskin Camera Case with silver-tone metal. It gives dimensions of **19.5 × 26.5 × 8.5 cm**, seasons 06P, 06C and 05A, and production in **2005-2006**. Those particulars are assertions by Luxury Evermore. No public Chanel catalogue or internal record was found to confirm them, so they are not used here as verified Chanel facts.
+A resale buyer therefore needs to understand the evidence offered by the seller and any specialist, rather than expect a serial lookup to provide an official guarantee.
 
-What is established on the public record is narrower:
+## A fictional purchase with a copied code
 
-- one database publisher reports 127 sightings of the same code;
-- its summary distributes those sightings across 36 named countries;
-- its detail page currently names only 35 countries;
-- the underlying submissions are not available for independent audit;
-- repeated use makes the code suspicious, but does not identify an original.
+Imagine a fictional resale shop receiving a bag whose serial number appears in the reseller's warning database. Staff should record the match and arrange the required examination. They should not jump directly from a repeated number to a final counterfeit accusation.
 
-That last point is the heart of the case.
+The specialist can examine the bag's construction and condition. Purchase and service documents may help establish its history, but their origin and relationship to this bag also need checking.
 
-## A code can be unique in a database and duplicated on objects
+If the seller provides a digital certificate, the shop should establish its issuer, claim and current status. The physical association remains a separate check. A certificate for a genuine bag can be copied and presented with another object.
 
-People often use three different ideas as if they were the same.
+These steps lead to an explanation the customer can understand: what has been established, what remains uncertain and which evidence is needed before the transaction can proceed.
 
-**An identifier** is a value used to distinguish a record. A serial string can perform this job perfectly inside a manufacturer's database.
+## A web address is another reference, not a verdict
 
-**An identity record** is the set of claims attached to that identifier. It might describe model, material, colour, production event, service history and current status.
+[GS1 Digital Link URI Syntax](https://ref.gs1.org/standards/digital-link/uri-syntax/) defines how identifiers can be expressed in web addresses. Its current specification says applications cannot infer that a syntactically matching address points to a conforming resolver, the service that directs a request to relevant information.
 
-**Proof** is what lets another party test who issued those claims and whether this object is the one they concern. That requires more than reading the identifier.
+The same practical distinction applies to a branded page reached by QR code. Loading a convincing page does not establish that the issuer is genuine or that the page describes the object being sold.
 
-A counterfeiter does not need to break a database to copy a printed code. One photograph, listing or physical example can reveal a plausible value. The string can then be printed on many objects, while each object points the human reader toward the same apparently valid story.
+Ask the provider to demonstrate those checks separately. A single green result that hides an unchecked issuer or physical association would give the buyer more certainty than the evidence supports.
 
-The database may still be correct that the identifier was meant to be unique. The failure happens outside the database, at the link between record and object. The identifier remains singular in software while becoming plural in leather, metal and stickers.
+## Frequently asked questions
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 270" role="img" aria-label="Diagram showing one copied code printed on many physical bags. Every bag resolves to the same record, so the database lookup succeeds while the physical identity remains unproven." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="27" fontSize="14" fontWeight="600" fill="#FFFFFF">One valid-looking code, many physical objects</text>
-    <rect x="134" y="46" width="172" height="42" rx="7" fill="#00FFFF" opacity="0.12" stroke="#22D3EE" strokeWidth="1" />
-    <text x="220" y="64" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#22D3EE">IDENTIFIER 10218184</text>
-    <text x="220" y="78" textAnchor="middle" fontSize="9.5" fill="rgba(255,255,255,0.72)">One lookup value</text>
-    <line x1="220" y1="88" x2="220" y2="118" stroke="#22D3EE" strokeWidth="1.5" />
-    <rect x="118" y="118" width="204" height="42" rx="7" fill="#041c30" stroke="rgba(0,255,255,0.35)" strokeWidth="1" />
-    <text x="220" y="136" textAnchor="middle" fontSize="10.5" fontWeight="600" fill="#FFFFFF">ONE DATABASE RECORD</text>
-    <text x="220" y="150" textAnchor="middle" fontSize="9.5" fill="rgba(255,255,255,0.7)">The lookup can still return a match</text>
-    <line x1="150" y1="160" x2="76" y2="194" stroke="#0E7490" strokeWidth="1.5" />
-    <line x1="196" y1="160" x2="172" y2="194" stroke="#0E7490" strokeWidth="1.5" />
-    <line x1="244" y1="160" x2="268" y2="194" stroke="#0E7490" strokeWidth="1.5" />
-    <line x1="290" y1="160" x2="364" y2="194" stroke="#0E7490" strokeWidth="1.5" />
-    <rect x="24" y="194" width="104" height="42" rx="7" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.16)" strokeWidth="1" />
-    <rect x="120" y="194" width="104" height="42" rx="7" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.16)" strokeWidth="1" />
-    <rect x="216" y="194" width="104" height="42" rx="7" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.16)" strokeWidth="1" />
-    <rect x="312" y="194" width="104" height="42" rx="7" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.16)" strokeWidth="1" />
-    <text x="76" y="219" textAnchor="middle" fontSize="10" fill="#FFFFFF">BAG A</text>
-    <text x="172" y="219" textAnchor="middle" fontSize="10" fill="#FFFFFF">BAG B</text>
-    <text x="268" y="219" textAnchor="middle" fontSize="10" fill="#FFFFFF">BAG C</text>
-    <text x="364" y="219" textAnchor="middle" fontSize="10" fill="#FFFFFF">REPORT 127</text>
-    <text x="220" y="258" textAnchor="middle" fontSize="9.5" fill="rgba(255,255,255,0.58)">A successful lookup proves the code was read, not which bag owns it.</text>
-  </svg>
-</div>
+### Does serial code 10218184 prove that a bag is counterfeit?
 
-## What Chanel itself promises, and what it does not
+No. Luxury Evermore reports repeated use of the code, but its public database does not expose the underlying submissions. A copied identifier cannot determine which physical bag, if any, originally received it.
 
-An older official [Chanel care document for handbags](https://services.chanel.com/media/files/en_GB_Care_instructions_for_Bags.pdf) describes the paper-era mechanism. It says each handbag is unique and comes with an individual identification card. It also says the card number is marked inside the item.
+### Does Chanel offer an authentication service for resale purchases?
 
-That document tells owners how the mechanism was intended to work. It does not publish a consumer-verifiable register, an issuer signature or a way to distinguish a copied card-and-sticker pair from the original pair.
+Chanel's United States fashion FAQ says authentication is not a service it offers. It limits its authenticity guarantee to purchases from its boutiques and listed authorised retailers.
 
-Chanel's current [United States fashion FAQ](https://www.chanel.com/us/faq/fashion/) draws a firmer commercial boundary. It says authentication is not a service the house offers. It guarantees authenticity only for products purchased from a Chanel boutique or an authorised retailer listed in its store locator.
+### Does a conforming GS1 Digital Link prove authenticity?
 
-The two official texts are compatible. A house can assign an individual number to every object it makes while declining to authenticate objects presented later through an open public service. The first is an internal production and after-sales capability. The second would be an external trust service for an enormous secondary market.
+No. The standard provides a way to express identifiers in web addresses. The address alone does not prove the truth of the information reached, the issuer's identity or the physical item's authenticity.
 
-For a buyer, the result is practical. A readable number is not a Chanel authentication response. A seller saying “the serial checks out” has usually shown only that the visible value fits a known format or period.
-
-The company has not published enough current handbag documentation to support stronger claims about its post-2021 identification architecture here. Inside Retail describes a shift to a microchip-based system, but that remains secondary reporting for this article. We do not treat the presence, behaviour or security properties of a current chip as an official Chanel fact.
-
-## A red-flag database answers a different question
-
-The Luxury Evermore list does something valuable. It turns scattered observations into a reuse warning. A reseller who encounters 10218184 can stop, compare the object with the claimed reference and commission deeper examination.
-
-But the list answers **“has this value appeared suspiciously often?”** It cannot answer **“which one is original?”** The count grows by sightings, not by cryptographically verified identities.
-
-That distinction changes the decision path:
-
-1. A code-format check asks whether the value looks plausible.
-2. A reuse search asks whether the value has appeared on conflicting objects.
-3. A physical examination asks whether materials, construction and ageing fit the claimed product.
-4. A provenance check asks where the seller obtained the bag and whether transaction evidence is coherent.
-5. An issuer-verification check asks whether the maker signed an item-level record that is still valid.
-6. A physical-binding check asks whether the responding carrier is still inseparable from the object that received it.
-
-Most consumer serial lookups stop after steps one or two. Professional authentication may add three and four. A verifiable identity system is designed to make five available outside the issuer. It still needs serious engineering to make six credible.
-
-This is also why automation can fail in both directions. In an unrelated [Reddit thread dated 5 August 2026](https://www.reddit.com/r/VestiaireCollective/comments/1vgd7lg/warning_for_sellers_vestiaire_collective_is_using/), user **Loud-Aerie4711** described a disputed marketplace rejection and wrote: **“They used AI to say my receipt was AI.”** The claim is an unverified customer account, not evidence about the platform's process. It illustrates the cost of a system that returns a verdict without exposing a checkable chain of evidence.
-
-A false acceptance lets a counterfeit through. A false rejection blocks a genuine owner. Better identity infrastructure does not eliminate expert judgement, but it can make the inputs and issuer claims inspectable.
-
-## What a stronger item identity needs
-
-A dependable architecture separates five layers. Each layer answers a question the copied string cannot.
-
-**1. Granularity.** Is the identifier assigned to a model, a production batch or one physical item? “Unique” has little meaning until the system states the population within which uniqueness applies.
-
-**2. Issuer authority.** Who created the record? The house should sign the identity claim with a verifiable key. A reseller should be able to confirm that signature without trusting a screenshot or the seller's app.
-
-**3. Data carrier.** How is the identifier presented on the object? A QR code, data matrix, NFC tag, secure chip or material marker can carry or reveal it. The choice affects cost, durability and resistance to copying.
-
-**4. Physical binding.** What stops a genuine carrier being copied, relayed or transplanted into another object? Tamper evidence, construction choices and challenge-response hardware can raise the attack cost. None makes the problem disappear.
-
-**5. State and events.** Can the record show issuance, sale, service, loss, theft, recall or retirement without exposing the owner's private data? A static birth certificate is weaker than a record whose status can be checked at the transaction moment.
-
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 306" role="img" aria-label="Five-layer item identity stack. Granularity states whether the record covers a model, batch or item. Issuer signature proves who made the claim. The carrier exposes the identifier. Physical binding connects the carrier to the object. State and events keep the record useful through resale and service." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="27" fontSize="14" fontWeight="600" fill="#FFFFFF">From a serial string to a verifiable item identity</text>
-    <rect x="20" y="45" width="400" height="40" rx="7" fill="rgba(0,255,255,0.05)" stroke="rgba(255,255,255,0.10)" strokeWidth="1" />
-    <text x="36" y="62" fontSize="10.5" fontWeight="600" fill="#22D3EE">1 · GRANULARITY</text>
-    <text x="190" y="62" fontSize="9.5" fill="rgba(255,255,255,0.76)">Model, batch or one item?</text>
-    <text x="190" y="76" fontSize="9.5" fill="rgba(255,255,255,0.56)">Define what “unique” means.</text>
-    <rect x="20" y="91" width="400" height="40" rx="7" fill="rgba(0,255,255,0.07)" stroke="rgba(255,255,255,0.10)" strokeWidth="1" />
-    <text x="36" y="108" fontSize="10.5" fontWeight="600" fill="#22D3EE">2 · ISSUER</text>
-    <text x="190" y="108" fontSize="9.5" fill="rgba(255,255,255,0.76)">The house signs the claim.</text>
-    <text x="190" y="122" fontSize="9.5" fill="rgba(255,255,255,0.56)">Anyone can verify its origin.</text>
-    <rect x="20" y="137" width="400" height="40" rx="7" fill="rgba(0,255,255,0.09)" stroke="rgba(255,255,255,0.10)" strokeWidth="1" />
-    <text x="36" y="154" fontSize="10.5" fontWeight="600" fill="#22D3EE">3 · CARRIER</text>
-    <text x="190" y="154" fontSize="9.5" fill="rgba(255,255,255,0.76)">QR, NFC, secure chip or marker.</text>
-    <text x="190" y="168" fontSize="9.5" fill="rgba(255,255,255,0.56)">Expose the identifier durably.</text>
-    <rect x="20" y="183" width="400" height="40" rx="7" fill="rgba(0,255,255,0.11)" stroke="rgba(255,255,255,0.10)" strokeWidth="1" />
-    <text x="36" y="200" fontSize="10.5" fontWeight="600" fill="#22D3EE">4 · BINDING</text>
-    <text x="190" y="200" fontSize="9.5" fill="rgba(255,255,255,0.76)">Connect carrier and object.</text>
-    <text x="190" y="214" fontSize="9.5" fill="rgba(255,255,255,0.56)">Resist copies and transplants.</text>
-    <rect x="20" y="229" width="400" height="40" rx="7" fill="rgba(0,255,255,0.13)" stroke="#22D3EE" strokeWidth="1" />
-    <text x="36" y="246" fontSize="10.5" fontWeight="600" fill="#22D3EE">5 · STATE</text>
-    <text x="190" y="246" fontSize="9.5" fill="rgba(255,255,255,0.76)">Issue, service, transfer, retire.</text>
-    <text x="190" y="260" fontSize="9.5" fill="rgba(255,255,255,0.56)">Check status at the transaction.</text>
-    <text x="220" y="293" textAnchor="middle" fontSize="9.5" fill="rgba(255,255,255,0.58)">All five are needed. A scan screen alone is not proof.</text>
-  </svg>
-</div>
-
-## Where GS1 Digital Link helps, and where it stops
-
-The [GS1 Digital Link standard](https://ref.gs1.org/standards/digital-link/) provides a consistent way to express GS1 identifiers in web addresses. Its companion resolver standard lets those identifiers point to one or more sources of related information or services.
-
-This solves an important interoperability problem. A product identifier can travel in a web-compatible form rather than being trapped inside one proprietary app. The same address can connect a scanner to instructions, product data, traceability resources or a service endpoint.
-
-The current [GS1 Digital Link URI Syntax specification](https://ref.gs1.org/standards/digital-link/uri-syntax/) is explicit about the boundary. A conforming URI, like any URL, has no intrinsic meaning on its own. Applications cannot assume even that it points to a conformant resolver.
-
-The security conclusion follows from the standard's scope. URI syntax proves that a string is well formed. Resolution proves that a service returned information for that string. Neither operation proves that the handbag under the scanner is the object to which the issuer assigned the identifier.
-
-An open identifier and resolver are therefore necessary rails, not an authenticity verdict. Issuer signatures, carrier security, physical binding and current status must sit on those rails.
-
-## What the EU Digital Product Passport really requires
-
-The [Ecodesign for Sustainable Products Regulation, Regulation (EU) 2024/1781](https://eur-lex.europa.eu/eli/reg/2024/1781/oj), creates the legal framework for Digital Product Passports. It does not yet impose one item-level passport on every luxury handbag.
-
-Article 9(2)(d) says the relevant delegated act must specify whether a passport corresponds to the **model, batch or item level**. Granularity is a product-group decision. Calling the framework universally item-level would overstate the law.
-
-Article 10 sets technical requirements for a passport. The data carrier must be physically present on the product, packaging or accompanying documentation, as specified by the delegated act. It must be connected to a persistent unique product identifier. The passport must also use open standards and interoperable formats.
-
-Article 11 requires passport design and operation to provide data authentication, reliability and integrity. It also addresses security, privacy and fraud avoidance. Article 12 sets standards for operator and facility identifiers, plus fallback rules for issuing and maintaining identifiers and carriers.
-
-These provisions create a stronger information architecture than an isolated serial sticker. They tell future product rules to define granularity, carrier placement, persistent identifiers, access and governance.
-
-They do not repeal the physical-binding problem. A printed carrier can be copied. A genuine tag can be moved. A resolver can show authentic data after a counterfeit object presents a cloned address. Compliance data and object authenticity overlap, but they are not identical claims.
-
-For a luxury house, the practical design choice is to build beyond the minimum carrier requirement. Use the passport identifier as the index, then add issuer-signed claims and a carrier whose response is difficult to duplicate. Record lifecycle events without making the owner's identity public.
-
-## The reseller checklist: search key first, evidence second
-
-A reseller should never discard a serial code. It should change what the code is allowed to prove.
-
-**At intake:** photograph the object and identifier together. Preserve seller declarations, transaction documents and timestamps. A detached close-up of a code loses the relation to the submitted bag.
-
-**At lookup:** test format and expected period, then search internal and external reuse records. A conflicting model, colour or geography raises risk. It does not establish criminal intent or settle authenticity by itself.
-
-**At examination:** compare construction, materials, hardware, dimensions, wear and repairs with known references. Record the expert, method and confidence. Do not collapse a multi-factor assessment into “serial valid”.
-
-**At issuer proof:** if a house-backed record exists, verify its issuer signature and current status. Do not trust a screenshot, a copied certificate image or a branded landing page merely because it loads.
-
-**At physical binding:** test the carrier's security properties. A secure chip should answer a fresh challenge, not replay a fixed string. The attachment should reveal removal or transplantation where the product permits it.
-
-**At sale:** give the buyer the evidence bundle and its limits. Transfer the item record when the system supports ownership events. Keep personal details outside any public ledger.
-
-This workflow makes uncertainty explicit. A reused code can trigger escalation without pretending a crowd-sourced list is a court finding. A successful issuer check can strengthen the file without pretending a chip makes material expertise obsolete.
-
-## The maison checklist: issue authority once, preserve it through resale
-
-For a maison, the lesson is not “replace the sticker with a chip.” A static value inside an NFC tag can reproduce the same failure in a more expensive component.
-
-The stronger target is an identity that survives channel changes:
-
-- assign at item level when the value proposition or product rule requires it;
-- sign the record with an issuer key whose authority can be verified independently;
-- use a carrier appropriate to the item's lifespan, service environment and attack model;
-- design the carrier and product together so removal leaves evidence;
-- expose status without exposing the customer's name;
-- support service, repair, loss and retirement events;
-- let ownership transfer without rewriting the original manufacturing claim;
-- publish verification rules and failure states for resellers and auction houses;
-- retain a recovery path when a carrier fails on a genuine item.
-
-The final point is easy to miss. Luxury goods outlive phones, apps and sometimes technology providers. A secure identity must be repairable without making silent replacement an authenticity loophole.
-
-## What no digital identity can promise
-
-There is no perfect anti-counterfeit carrier.
-
-A QR code is cheap and accessible, but trivially photographed. A basic NFC tag improves the experience, but may expose a static response. A cryptographic chip can resist copying, yet still be relayed or physically transplanted. Tamper evidence can raise the cost of removal, but artisans can attack seams and components.
-
-Issuer systems can also fail. Keys can be compromised, access can be abused and incorrect data can be signed. A technically valid claim is only as trustworthy as the issuer's controls and correction process.
-
-Privacy creates another constraint. A buyer needs to know that a bag is genuine, active and transferable. They do not need a public list of every prior owner, address or purchase price. Provenance should mean verifiable events, not permanent consumer surveillance.
-
-Finally, not every legacy bag can receive a birth record from its maker. Retrospective authentication remains an expert judgement made later. A system should label that distinction instead of presenting a later appraisal as original issuance.
-
-The correct promise is modest and valuable. Digital identity can make issuer claims portable, checks reproducible and lifecycle state visible. It can sharply reduce reliance on a copied string. It cannot turn every scan into certainty.
-
-## Galileo's take
-
-**The 10218184 case is not mainly a story about one suspicious number. It is a demonstration of the distance between an identifier and an identity.** A database of sightings detects reuse. An expert assesses the object. An issuer-signed record establishes who made a claim. A secure physical anchor connects that claim to the item presented today.
-
-Those functions should reinforce one another. None should impersonate the others.
-
-Galileo Protocol builds the portable record layer for physical assets: verifiable digital twins, issuer attestations and interoperable lifecycle events. The architecture is designed so a buyer can inspect the authority behind a claim, while personal data remains outside the public record.
-
-Explore the [Galileo Protocol documentation](/docs), read the open [specifications](/specifications), or [contact the team](mailto:info@galileoprotocol.io) to discuss item-level identity for luxury goods.
-
-## Sources
-
-- [Luxury Evermore, Red Flag Chanel Datecode Database](https://luxuryevermore.com/pages/chanel-counterfeit-bags-red-flag-serial-numbers-database): publisher's current summary for code 10218184, count 127 and 36-country list; marked last updated 21 August 2026. Consulted 2 September 2026.
-- [Luxury Evermore, detail page for 10218184](https://luxuryevermore.com/pages/red-flag-chanel-datecode-serial-number-10218184): product-reference claims and a 35-country list that omits Belgium. Consulted 2 September 2026.
-- [Chanel, Fashion FAQ](https://www.chanel.com/us/faq/fashion/): authentication is not offered as a service; authenticity guarantee is limited to Chanel boutiques and authorised retailers. Consulted 2 September 2026.
-- [Chanel, Care Instructions for Bags](https://services.chanel.com/media/files/en_GB_Care_instructions_for_Bags.pdf): official description of the identification-card and matching-number mechanism. Consulted 2 September 2026.
-- [Regulation (EU) 2024/1781, ESPR](https://eur-lex.europa.eu/eli/reg/2024/1781/oj): Articles 9 to 12 on passport granularity, data carriers, identifiers, integrity and lifecycle. Official Journal text.
-- [GS1 Digital Link](https://ref.gs1.org/standards/digital-link/) and [URI Syntax](https://ref.gs1.org/standards/digital-link/uri-syntax/): standards for expressing identifiers in web addresses and resolving them to information or services. Consulted 2 September 2026.
-- [Irene Dong, Inside Retail Asia](https://insideretail.asia/2026/08/25/chanel-scam-luxury-reseller-calls-out-widely-reused-serial-code/), 25 August 2026: reporting and attributed comment from Luxury Evermore founder Mingchuan Tian.
-- [Loud-Aerie4711, Reddit r/VestiaireCollective](https://www.reddit.com/r/VestiaireCollective/comments/1vgd7lg/warning_for_sellers_vestiaire_collective_is_using/), 5 August 2026: unverified customer account used only to illustrate the cost of opaque false-rejection claims.
-
-## FAQ
-
-### Does Chanel serial number 10218184 prove that a bag is fake?
-
-No. [Luxury Evermore reports](https://luxuryevermore.com/pages/chanel-counterfeit-bags-red-flag-serial-numbers-database) seeing that code 127 times in submissions from 36 countries, which makes it a warning signal. The public database does not expose the underlying submissions for independent review. A copied code also cannot identify which physical bag, if any, received it legitimately. The bag, its construction, its provenance and the seller must still be examined.
-
-### Can Chanel authenticate a pre-owned handbag?
-
-Chanel's [United States fashion FAQ](https://www.chanel.com/us/faq/fashion/) says product authentication is not a service the house offers. It says authenticity is guaranteed only for products bought from a Chanel boutique or an authorised retailer. That leaves a secondary-market buyer relying on seller evidence, specialist examination and any product record made available by the issuer.
-
-### Is a microchip stronger than a printed serial number?
-
-It can be, but only if the chip does more than reveal a static value. A static NFC response can be copied or relayed. A stronger design uses a chip that proves possession of a secret through a changing cryptographic challenge. The design must also bind that chip to the bag so it cannot be transplanted without detection.
-
-### Does the EU Digital Product Passport require one unique identity per luxury bag?
-
-Not automatically. [Article 9 of the ESPR](https://eur-lex.europa.eu/eli/reg/2024/1781/oj) says a delegated act must decide whether a passport applies at model, batch or item level. Articles 10 to 12 establish the data-carrier and identifier architecture. A future product rule could require item-level granularity, but the framework itself does not yet impose that level on every handbag.
-
-### What should a reseller verify before accepting a luxury bag?
-
-Treat the visible code as a search key, not a verdict. Check whether it matches the product family and production period, search for reuse, inspect the physical object, and verify seller evidence. Record who performed each check. If an issuer-signed item record exists, verify its signature, status and physical binding rather than trusting the scan screen alone.
+See the [Galileo documentation](/docs) for product-record concepts and the [revocation guide](/blog/2026-09-05-product-passport-revocation-resale) for checking whether a digital attestation can still be relied on.

--- a/website/content/blog/2026-09-03-mica-bitpanda-marketing-paper-trail.mdx
+++ b/website/content/blog/2026-09-03-mica-bitpanda-marketing-paper-trail.mdx
@@ -1,10 +1,14 @@
 ---
-title: "MiCA Enforcement: Bitpanda's €70,000 Paperwork Fine"
-date: "2026-09-03"
-modified: "2026-09-03"
-author: "Pierre Beunardeau"
-excerpt: "Bitpanda's €70,000 sanction shows that MiCA marketing depends on sequencing. Here is the release file a tokenized handbag needs before launch."
-description: "Bitpanda's €70,000 sanction shows that MiCA marketing depends on sequencing. Here is the release file a tokenized handbag needs before launch."
+title: 'MiCA Marketing Rules: Bitpanda''s €70,000 Sanction'
+date: '2026-09-03'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  Bitpanda's €70,000 sanction shows why a required white paper must precede
+  marketing. Follow the applicable MiCA sequence and avoid blanket assumptions.
+description: >-
+  Bitpanda's €70,000 sanction shows why a required white paper must precede
+  marketing. Follow the applicable MiCA sequence and avoid blanket assumptions.
 tags:
   - mica
   - tokenization
@@ -12,237 +16,75 @@ tags:
   - compliance
   - luxury
 published: true
-coverImage: "/images/blog/mica-bitpanda-marketing-paper-trail.jpg"
-coverImageAlt: "An unbranded luxury handbag, blank documents and a glass token connected by cyan light on an obsidian background"
+coverImage: /images/blog/mica-bitpanda-marketing-paper-trail.jpg
+coverImageAlt: >-
+  An unbranded luxury handbag, blank documents and a glass token connected by
+  cyan light on an obsidian background
 faq:
-  - question: "Why did Austria's FMA fine Bitpanda €70,000?"
-    answer: "The FMA says Bitpanda notified a crypto-asset white paper too late and sent marketing before publishing it. A communication also omitted mandatory responsibility, regulatory-review and contact information. The final penal order was announced on 14 August 2026."
-  - question: "Does every tokenized handbag require a MiCA white paper?"
-    answer: "No. The answer depends on the represented rights, transferability, uniqueness, offer and any other applicable financial-services regime. The label NFT, digital twin or product passport is not decisive."
-  - question: "When must a Title II MiCA white paper be notified?"
-    answer: "Article 8 requires the white paper and classification explanation to reach the home authority at least 20 working days before publication. This Title II process is notification, not prior approval."
-  - question: "Can a project market a Title II token before publishing its white paper?"
-    answer: "Not where Articles 4 or 5 require a white paper. Article 7(2) prohibits marketing communications before that white paper is published. The marketing must also be identifiable, fair, clear, not misleading and consistent with the white paper."
-  - question: "What should a tokenized-goods launch file contain?"
-    answer: "Keep the classification and assumptions, signed white-paper version, notification receipt, published file, approved marketing, required contacts and disclaimer, publication evidence, approvals and change log. The applicable list depends on the token and offer."
+  - question: What did the FMA's Bitpanda sanction concern?
+    answer: >-
+      The FMA's 14 August 2026 announcement describes a final €70,000 penalty
+      for MiCA breaches concerning white-paper timing and marketing, including
+      omitted required information.
+  - question: Does notification mean that the regulator approves the white paper?
+    answer: >-
+      Under the title II procedure in MiCA article 8, notification is not prior
+      approval. Do not extend that statement to every category of crypto-asset
+      or imply official endorsement of the offer.
+  - question: Does every digital product passport need a MiCA white paper?
+    answer: >-
+      No. Establish the rights, transferability and applicable regime first. A
+      product-data record, an excluded crypto-asset and an in-scope public offer
+      are not automatically subject to the same requirements.
 ---
+Bitpanda's €70,000 sanction illustrates why marketing cannot run ahead of a white paper when MiCA requires one. The lesson for a token offer is to establish the applicable regime, then align notification, publication and communications before launch.
 
-Austria's FMA fined Bitpanda GmbH **€70,000** for a late MiCA white-paper notification and defective marketing sequencing, in a final order announced on 14 August 2026. For a tokenized-handbag project, the practical lesson is to classify the token before launch and make publication evidence, marketing copy, contacts and the 20-working-day notification clock one release file.
+The [Austrian FMA announcement of 14 August 2026](https://www.fma.gv.at/en/announcement-fma-imposes-sanction-against-bitpanda-gmbh-for-breaches-against-micar/) describes a final penalty concerning white-paper timing and marketing. It includes missing required statements and contact information, not simply a failure to file an optional administrative document.
 
-The case is not evidence that a tokenized handbag is automatically regulated by MiCA. It is evidence that, once a launch falls under MiCA's disclosure rules, a missing date, a premature campaign or an incomplete footer can become an enforcement matter.
+## Begin by identifying the offer
 
-## What the FMA actually published
+MiCA is the EU Markets in Crypto-Assets Regulation. The title II rules discussed here concern crypto-assets other than asset-referenced tokens and electronic-money tokens.
 
-The primary record is short and unusually concrete. In its [14 August 2026 sanction announcement](https://www.fma.gv.at/en/announcement-fma-imposes-sanction-against-bitpanda-gmbh-for-breaches-against-micar/), Austria's Financial Market Authority says it imposed a **€70,000** fine on Bitpanda GmbH. It identifies four failures:
+[Article 4](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-4-offers-public-crypto-assets-other) sets conditions for public offers and also contains exemptions. Establish whether those rules apply before assigning the same launch checklist to every token.
 
-1. The required crypto-asset white paper was not submitted to the FMA at least **20 working days before its publication date**.
-2. A marketing communication was issued before the required white paper had been published.
-3. A marketing communication omitted the mandatory statement that no competent EU authority had reviewed or approved it and that the offeror was solely responsible for its content.
-4. The communication omitted the required telephone number and email address.
+A digital product passport that provides care information does not become a regulated investment merely because software calls its record a token. Conversely, attaching a product identifier to a financial or redemption arrangement does not settle its legal classification. The rights, transferability and services matter.
 
-The FMA says the proceedings ended through an accelerated procedure under Austria's Financial Market Authority Act and that the penal order is final. Its separate notice calls this the [first legally final MiCAR penal order published by the FMA](https://www.fma.gv.at/en/first-micar-penal-order-published/). The authority also cautions that being the first published case gives neither the company nor the breaches any special status.
+## Keep the sequence clear
 
-That wording matters. It does not establish the first MiCA fine anywhere in the European Union. It establishes the first such final order that this Austrian authority published. The FMA announcement also does **not** name the crypto-asset concerned, date the underlying conduct, reproduce the marketing communication or say that customers lost money. Those gaps should stay gaps.
+For the relevant white paper, [article 8](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-8-notification-crypto-asset-white) requires notification and the prescribed explanation at least **20 working days before publication**. Under this procedure, notification is not prior approval.
 
-The public record is therefore narrower than some headlines. It documents a final Austrian sanction for notification and marketing failures. It does not support a theory about the product, the campaign's commercial result or a customer-harm amount.
+[Article 7](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-7-marketing-communications) governs the marketing itself. Where a white paper is required, marketing must not be disseminated before it is published. The communications must also carry the required information and remain consistent with the white paper.
 
-Two outside reactions capture why the case travelled beyond crypto compliance teams. On LinkedIn on 17 August, **Alberto Borri** wrote: **“MiCA is no longer a compliance project. It is an enforcement reality.”** That is his interpretation of the announcement, not proof of the underlying breaches, which comes from the FMA.
+[Article 9](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-9-publication-crypto-asset-white) then addresses publication before the offer or admission to trading begins. A team should be able to follow the versions and dates across that sequence, not just point to a current page after the event.
 
-The following day, chartered accountant **Simran Agarwal** asked a sharper operational question: **“Would your team have actually caught this before the regulator did?”** Again, this is commentary. Its value is to move the discussion from reading the rule to testing the release process.
+## A fictional launch that needs a hold
 
-## Why this is a launch-control case, not a licensing case
+Consider a fictional company preparing an in-scope public offer for which a white paper is required. Its marketing team has scheduled a campaign, but the white paper is still being revised.
 
-The earlier Galileo analysis, [MiCA Transition Ends: RWA Tokenization Leaves the Grey Zone](/blog/2026-08-25-mica-transitional-period-rwa), dealt with authorisation and classification after the transitional period. This case starts one step later. It asks what happens between a legal conclusion and the first public campaign.
+The useful response is to hold the dependent campaign until the applicable sequence is satisfied. Changing the campaign label to “community update” would not answer whether its substance is marketing.
 
-The answer is that the conclusion has to survive operations.
+The person responsible for the offer should identify the relevant document version, evidence of notification, publication date and matching communication. If the promised rights change, the team needs to assess the change under the applicable rules before reusing an earlier version.
 
-For crypto-assets other than asset-referenced tokens or e-money tokens, [MiCA Article 4](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-4-offers-public-crypto-assets-other) sets the basic public-offer conditions. Where no exemption applies, the offeror must draw up, notify and publish a white paper, prepare and publish compliant marketing, and meet its ongoing duties.
+This is a proposed operating example, not a description of Bitpanda's internal process or a classification of a real luxury offer.
 
-[Article 8](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-8-notification-crypto-asset-white) makes the timing precise. The offeror, person seeking admission to trading or relevant platform operator notifies the home authority. The notification includes an explanation of why the asset is not excluded under Article 2(4) and why it is neither an asset-referenced token nor an e-money token. Those elements must arrive **at least 20 working days before publication of the white paper**.
+## Make the customer's information consistent
 
-This is a notification regime. Article 8(3) says competent authorities do not require prior approval of the white paper or its related marketing before publication. That does not make the waiting period optional. It means the release gate is a provable notification and elapsed statutory period, not a regulator's approval email.
+A buyer should not receive one promise in an advertisement and another in the document defining the offer. Review the stated rights, risks, issuer and contact route together.
 
-[Article 7](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-7-marketing-communications) governs the communications. They must be recognisable as marketing, fair, clear and not misleading, and consistent with the white paper where one is required. They must point to the published white paper, give the relevant website, telephone number and email address, and carry the prescribed responsibility and no-regulatory-approval statement.
+The practical deliverable is a coherent public explanation with the required sequence behind it. A folder of documents cannot compensate for misleading claims, and a standards logo does not establish legal permission.
 
-The sequence is explicit. When Articles 4 or 5 require a white paper, no marketing communication may be disseminated before that white paper is published. [Article 9](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-9-publication-crypto-asset-white) then requires the white paper and marketing versions to be publicly accessible on the website before the offer or admission to trading begins. The published white paper, and marketing notified upon request, must match the notified versions, subject to the regulation's modification process.
+## Frequently asked questions
 
-That creates three separate timestamps:
+### What did the FMA's Bitpanda sanction concern?
 
-- notification received by the competent authority;
-- white paper published on the offeror's public website;
-- marketing communication released.
+The FMA's 14 August 2026 announcement describes a final €70,000 penalty for MiCA breaches concerning white-paper timing and marketing, including omitted required information.
 
-Treating them as one “launch date” hides the exact sequence that the FMA enforced.
+### Does notification mean that the regulator approves the white paper?
 
-<div style={{ margin: '2rem 0', padding: '1.25rem 1rem', background: 'var(--graphite)', border: '1px solid rgba(0, 255, 255, 0.1)', borderRadius: '0.75rem' }}>
-  <svg viewBox="0 0 440 396" role="img" aria-label="MiCA Title II release sequence. First classify the token. Second freeze the white paper and its classification explanation. Third notify the home authority at least 20 working days before publishing the white paper. Fourth publish the identical white paper. Fifth release compliant marketing only after publication. Sixth open the public offer and retain the evidence." style={{ width: '100%', height: 'auto', display: 'block' }} fontFamily="ui-sans-serif, system-ui, sans-serif">
-    <text x="20" y="27" fontSize="14" fontWeight="600" fill="#FFFFFF">A release sequence that leaves evidence</text>
-    <line x1="46" y1="57" x2="46" y2="350" stroke="#22D3EE" strokeWidth="2" opacity="0.65" />
-    <circle cx="46" cy="70" r="8" fill="#00FFFF" />
-    <rect x="72" y="46" width="348" height="48" rx="7" fill="rgba(0,255,255,0.06)" stroke="rgba(0,255,255,0.22)" />
-    <text x="88" y="65" fontSize="10.5" fontWeight="600" fill="#22D3EE">1 · CLASSIFY THE TOKEN</text>
-    <text x="88" y="81" fontSize="9.5" fill="rgba(255,255,255,0.72)">Scope, rights, offer, exemptions</text>
-    <circle cx="46" cy="126" r="8" fill="#00FFFF" opacity="0.9" />
-    <rect x="72" y="102" width="348" height="48" rx="7" fill="rgba(0,255,255,0.07)" stroke="rgba(0,255,255,0.22)" />
-    <text x="88" y="121" fontSize="10.5" fontWeight="600" fill="#22D3EE">2 · FREEZE THE WHITE PAPER</text>
-    <text x="88" y="137" fontSize="9.5" fill="rgba(255,255,255,0.72)">One signed version and explanation</text>
-    <circle cx="46" cy="182" r="8" fill="#00FFFF" opacity="0.8" />
-    <rect x="72" y="158" width="348" height="48" rx="7" fill="rgba(0,255,255,0.08)" stroke="rgba(0,255,255,0.25)" />
-    <text x="88" y="177" fontSize="10.5" fontWeight="600" fill="#22D3EE">3 · NOTIFY THE HOME AUTHORITY</text>
-    <text x="88" y="193" fontSize="9.5" fill="rgba(255,255,255,0.72)">At least 20 working days before publication</text>
-    <circle cx="46" cy="238" r="8" fill="#00FFFF" opacity="0.7" />
-    <rect x="72" y="214" width="348" height="48" rx="7" fill="rgba(0,255,255,0.09)" stroke="rgba(0,255,255,0.28)" />
-    <text x="88" y="233" fontSize="10.5" fontWeight="600" fill="#22D3EE">4 · PUBLISH THE WHITE PAPER</text>
-    <text x="88" y="249" fontSize="9.5" fill="rgba(255,255,255,0.72)">Public URL, version matches notification</text>
-    <circle cx="46" cy="294" r="8" fill="#00FFFF" opacity="0.6" />
-    <rect x="72" y="270" width="348" height="48" rx="7" fill="rgba(0,255,255,0.10)" stroke="rgba(0,255,255,0.31)" />
-    <text x="88" y="289" fontSize="10.5" fontWeight="600" fill="#22D3EE">5 · RELEASE COMPLIANT MARKETING</text>
-    <text x="88" y="305" fontSize="9.5" fill="rgba(255,255,255,0.72)">After publication, with contacts and notice</text>
-    <circle cx="46" cy="350" r="8" fill="#00FFFF" opacity="0.5" />
-    <rect x="72" y="326" width="348" height="48" rx="7" fill="rgba(0,255,255,0.11)" stroke="#22D3EE" />
-    <text x="88" y="345" fontSize="10.5" fontWeight="600" fill="#22D3EE">6 · OPEN THE OFFER</text>
-    <text x="88" y="361" fontSize="9.5" fill="rgba(255,255,255,0.72)">Retain evidence and control later changes</text>
-    <text x="20" y="390" fontSize="9" fill="rgba(255,255,255,0.52)">Reading grid for a Title II launch where a white paper is required.</text>
-  </svg>
-</div>
+Under the title II procedure in MiCA article 8, notification is not prior approval. Do not extend that statement to every category of crypto-asset or imply official endorsement of the offer.
 
-## Before paperwork, classify the tokenized handbag
+### Does every digital product passport need a MiCA white paper?
 
-“Tokenized handbag” is not a legal category. It can describe several architectures that look similar in a product demo and lead to different rules.
+No. Establish the rights, transferability and applicable regime first. A product-data record, an excluded crypto-asset and an in-scope public offer are not automatically subject to the same requirements.
 
-Start with MiCA's [Article 3 definition of a crypto-asset](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-3-definitions). It is a digital representation of a value or right that can be transferred and stored electronically using distributed-ledger or similar technology. A non-transferable product credential used only to read authenticity or care data may fail that definition. Calling it a token does not make it transferable.
-
-If it is a crypto-asset, [Article 2(3)](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-2-scope) excludes crypto-assets that are genuinely unique and non-fungible. A digital twin tied to one particular handbag may fit that route, but the assessment is about substance. MiCA's recital 11 says a unique identifier alone is insufficient and fractional interests are not unique and non-fungible. Issuance in a large series or collection indicates fungibility.
-
-ESMA's [guidelines on qualification of crypto-assets as financial instruments](https://www.esma.europa.eu/document/guidelines-conditions-and-criteria-qualification-crypto-assets-financial-instruments) add a case-by-case test. They tell authorities and market participants to consider whether value comes primarily from unique characteristics or utility and how interdependent the token's value is with other assets in the series. The examples clarify the analysis; they do not deliver a classification certificate.
-
-The rights matter as much as the object:
-
-- A transferable proof representing one specific bag, with no pooled return or fractionalisation, may support the unique-and-non-fungible exclusion.
-- Thousands of interchangeable access tokens for the same concierge service may look like utility tokens in MiCA's residual Title II category.
-- Fractions sold as exposure to a bag's resale proceeds can raise financial-instrument questions. Article 2(4)(a) excludes financial instruments from MiCA because securities law applies instead.
-- A token seeking to maintain stable value by referencing assets or rights may be an asset-referenced token, which sits under MiCA Title III rather than the Article 7 and 8 route examined here.
-- A token referencing the value of one official currency can be an e-money token, governed by Title IV.
-
-This is why the Bitpanda checklist should not be pasted onto every digital passport. Articles 7 and 8 discussed in the sanction concern crypto-assets **other than** asset-referenced tokens and e-money tokens. A maison first records the represented right, transfer mechanics, holder benefits, pricing, audience, trading plan and redemption logic. Counsel then classifies the actual design.
-
-## The tokenized-handbag release file
-
-Assume a hypothetical maison plans a transferable token linked to each handbag. The token lets an owner carry an issuer-signed provenance record into resale and access a servicing programme. Counsel concludes that the public offer falls under MiCA Title II and that no Article 4 exemption removes the white-paper obligations.
-
-The project now needs one controlled release file. Not a folder assembled after launch, but the evidence used to decide whether launch is allowed.
-
-### 1. The classification note
-
-Record what the token represents, whether it is transferable, and whether the underlying bag and rights are unique. Add any fractionalisation, interchangeability across a series, offer audience and admission-to-trading plan.
-
-List the rejected classifications too. Article 8(4) requires an explanation of why a Title II asset is not excluded under Article 2(4), not an e-money token and not an asset-referenced token. A conclusion without its assumptions becomes dangerous when product design changes.
-
-### 2. The frozen white-paper package
-
-[Article 6](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-6-content-and-form-crypto-asset) makes the white paper a disclosure document, not a brand manifesto. It covers the offeror and issuer, project, offer, asset, rights and obligations, technology, risks and specified environmental information. The information must be fair, clear, not misleading, concise and comprehensible, without material omissions.
-
-The release file should contain the exact notified document, its hash, the responsible owner, the approval record and the machine-readable production file. The [Commission's implementing template](https://eur-lex.europa.eu/eli/reg_impl/2024/2984/oj/eng) standardises the forms and formats. Keeping only a final PDF is not enough if the structured source that generated it can drift.
-
-### 3. Proof of notification and the clock
-
-Store the submission receipt, authority, timestamp, timezone and the intended publication date. Calculate **20 working days**, not 20 calendar days. Record the holiday calendar and the person who verified it.
-
-Do not use the offer opening as the start of that count. Article 8(5) measures back from **publication of the white paper**. Article 9 separately requires publication before the public offer begins.
-
-A reliable gate joins the two systems. Content cannot publish before the recorded statutory date. Campaigns cannot release MiCA marketing until the public white-paper URL returns the frozen version.
-
-### 4. A marketing inventory, not one approved advert
-
-Marketing communications include more than the launch landing page. The team should inventory email, paid placements, social posts, influencer briefs, event screens, app banners, marketplace cards, partner copy and local-language variants.
-
-Each item needs a version, owner, audience, planned time, white-paper consistency check, public link, phone number, email address and the Article 7 responsibility statement. The legal rule applies to the communication that reaches prospective holders. A compliant master deck does not cure an incomplete social crop.
-
-The white-paper link must be live before release. A staging URL, access-controlled file or scheduled page is not evidence of public publication. Capture the live page, response time, document hash and the campaign release time.
-
-### 5. Change control after publication
-
-Campaigns change quickly. A product team may add transferability, a marketplace may add trading, or a rewards promise may become an economic right. Those are not ordinary copy edits if they disturb classification or the white paper.
-
-The file needs a change log connecting product requirements, legal classification, white-paper version and campaign claims. When a material fact changes, pause affected communications and apply MiCA's modification rules before treating the new copy as releasable.
-
-## What the marketing team can say about the handbag
-
-Article 7 requires marketing to be fair, clear, not misleading and consistent with the white paper. That turns common luxury-tech phrases into controlled claims.
-
-“Guaranteed authentic forever” needs evidence about the issuer's attestation, physical binding, key custody, revocation and what a successful scan proves. A blockchain entry can show that a record was written. It cannot, on its own, prove that the responding chip is still attached to the original bag.
-
-“Regulator approved” conflicts with the Title II notification model. Article 8(3) says no prior approval is required, while Article 7 requires the marketing communication to say it was not reviewed or approved by a competent EU authority. Notification is not endorsement.
-
-“A safe investment” is doubly hazardous. It can be misleading, and an investment framing may affect the classification analysis. The product team cannot decide that a token is a mere digital twin while the campaign sells expected returns.
-
-“Exclusive access” also needs detail. If the token provides access to a good or service already in operation, Article 4 contains a specific utility-token exemption. Its conditions and limits must be tested against the real offer, including any stated intention to seek admission to trading. A slogan is not the analysis.
-
-The practical rule is to link every campaign claim to one of three records: a white-paper disclosure, an independently verifiable product control or a clearly bounded opinion. If no record supports it, the claim does not ship.
-
-## A release meeting that can stop the campaign
-
-Give the gate to named owners. Product confirms the token mechanics. Legal confirms the classification and applicable MiCA title. Compliance owns notification evidence and timing. Marketing owns the complete communications inventory. Engineering proves the public file and version. An accountable executive approves release only after each dependency is green.
-
-At the meeting, ask six yes-or-no questions:
-
-1. Is the classification note about the product that will actually ship?
-2. Does the published white paper match the notified version?
-3. Has the 20-working-day period elapsed before publication?
-4. Is the white paper publicly reachable before every marketing release?
-5. Does every communication contain the required link, contacts and responsibility statement?
-6. Is every material claim consistent with the white paper and product evidence?
-
-A “no” pauses only the affected release. That is cheaper than debating after publication whether a scheduled post counted as marketing.
-
-The FMA did not publish Bitpanda's internal process, so this article does not claim which control failed there. The control design above is an inference from the four breaches the authority named. It is a way to prevent the same classes of failure, not a reconstruction of Bitpanda's operations.
-
-## What this changes for luxury tokenization
-
-MiCA enforcement does not make tokenization impossible. It makes sequencing observable.
-
-For a maison, the first deliverable is not the token contract or the campaign. It is a classification file that stays synchronized with both. If the result is outside MiCA because the asset and right are genuinely unique and non-fungible, preserve the reasoning. If Title II applies, start the notification clock before reserving an immutable campaign date. If ART, EMT or financial-instrument rules apply, switch tracks rather than forcing the launch through an Article 7 template.
-
-For a marketplace or technology provider, “MiCA ready” should describe controls, not a badge. Ask whether the system can freeze versions, prove publication order, stop scheduled communications, keep local variants consistent and retain receipts. The statutory footer is the visible end of a larger evidence chain.
-
-For a buyer, the white paper remains disclosure, not approval. It explains the asset, rights, technology and risks. It does not certify the physical handbag, guarantee liquidity or promise future value.
-
-That distinction is exactly where product identity and market conduct meet. Galileo's protocol can support an issuer-signed identity and event history for the object. It does not classify an offer, approve a white paper or replace the issuer's MiCA obligations.
-
-## Galileo's take
-
-**Galileo's take: the launch file should be as verifiable as the token.** Proving handbag provenance solves only half the trust problem. The team must also prove the notified white-paper version, publication time and subsequent campaign.
-
-The useful architecture joins two trails without confusing them. The product trail records issuance, authenticity claims, transfers, service and status. The regulatory trail records classification assumptions, disclosures, notification, publication, marketing approval and change control. One answers “what happened to this object?” The other answers “was this offer communicated in the required order?”
-
-Explore the [Galileo documentation](/docs) to see how verifiable physical-asset identity is structured, or [contact us](mailto:info@galileoprotocol.io) to discuss a tokenization design before campaign dates harden. This article is a practical reading of public sources, not legal or investment advice.
-
-## Primary sources
-
-- [Austrian FMA sanction announcement, 14 August 2026](https://www.fma.gv.at/en/announcement-fma-imposes-sanction-against-bitpanda-gmbh-for-breaches-against-micar/): amount, named breaches, accelerated procedure and final status.
-- [Austrian FMA publication notice, 14 August 2026](https://www.fma.gv.at/en/first-micar-penal-order-published/): first legally final MiCAR penal order published by that authority and its stated enforcement significance.
-- [Regulation (EU) 2023/1114](https://eur-lex.europa.eu/eli/reg/2023/1114/oj/eng), especially Articles 2 to 9 and recital 11: scope, classification, offer, white-paper, marketing, notification and publication rules.
-- [Commission Implementing Regulation (EU) 2024/2984](https://eur-lex.europa.eu/eli/reg_impl/2024/2984/oj/eng): standard forms, formats and templates for MiCA white papers.
-- [ESMA crypto-asset qualification guidelines](https://www.esma.europa.eu/document/guidelines-conditions-and-criteria-qualification-crypto-assets-financial-instruments): the case-by-case financial-instrument, utility-token and NFT analysis.
-
-## FAQ
-
-### Why did Austria's FMA fine Bitpanda €70,000?
-
-The FMA says Bitpanda notified a crypto-asset white paper too late and sent marketing before publishing it. A communication also omitted mandatory responsibility, regulatory-review and contact information. The final penal order was announced on 14 August 2026.
-
-### Does every tokenized handbag require a MiCA white paper?
-
-No. The answer depends on the represented rights, transferability, uniqueness, offer and any other applicable financial-services regime. The label NFT, digital twin or product passport is not decisive.
-
-### When must a Title II MiCA white paper be notified?
-
-Article 8 requires the white paper and classification explanation to reach the home authority at least 20 working days before publication. This Title II process is notification, not prior approval.
-
-### Can a project market a Title II token before publishing its white paper?
-
-Not where Articles 4 or 5 require a white paper. Article 7(2) prohibits marketing communications before that white paper is published. The marketing must also be identifiable, fair, clear, not misleading and consistent with the white paper.
-
-### What should a tokenized-goods launch file contain?
-
-Keep the classification and assumptions, signed white-paper version, notification receipt, published file, approved marketing, required contacts and disclaimer, publication evidence, approvals and change log. The applicable list depends on the token and offer.
+Our [MiCA transition guide](/blog/2026-08-25-mica-transitional-period-rwa) explains the broader scoping questions. Use the [Galileo documentation](/docs) when those choices are clear enough to design the supporting product records.

--- a/website/content/blog/2026-09-03-mica-bitpanda-marketing-paper-trail.mdx
+++ b/website/content/blog/2026-09-03-mica-bitpanda-marketing-paper-trail.mdx
@@ -37,7 +37,9 @@ faq:
       product-data record, an excluded crypto-asset and an in-scope public offer
       are not automatically subject to the same requirements.
 ---
-Bitpanda's €70,000 sanction illustrates why marketing cannot run ahead of a white paper when MiCA requires one. The lesson for a token offer is to establish the applicable regime, then align notification, publication and communications before launch.
+Bitpanda's €70,000 sanction illustrates why marketing cannot run ahead of a white paper when MiCA requires one. A [white paper](https://www.esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/article-6-content-and-form-crypto-asset) is the public document explaining the project, the token holder's rights and obligations, and the risks.
+
+Before launching a token offer, establish which rules apply, then align notification, publication and communications with them.
 
 The [Austrian FMA announcement of 14 August 2026](https://www.fma.gv.at/en/announcement-fma-imposes-sanction-against-bitpanda-gmbh-for-breaches-against-micar/) describes a final penalty concerning white-paper timing and marketing. It includes missing required statements and contact information, not simply a failure to file an optional administrative document.
 

--- a/website/content/blog/2026-09-05-product-passport-revocation-resale.mdx
+++ b/website/content/blog/2026-09-05-product-passport-revocation-resale.mdx
@@ -1,30 +1,60 @@
 ---
-title: "Product Passport Revocation: What Resale Must Check"
-date: "2026-09-05"
-modified: "2026-09-05"
-author: "Pierre Beunardeau"
-excerpt: "A revoked product credential does not prove a fake. A resale guide to checking current status, handling stale results and protecting owner privacy."
-description: "A revoked product credential does not prove a fake. A resale guide to checking current status, handling stale results and protecting owner privacy."
-tags: [provenance, authentication, infrastructure, luxury]
+title: 'Product Passport Revocation: What Resale Must Check'
+date: '2026-09-05'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  A revoked product credential does not prove a fake. A resale guide to checking
+  current status, handling stale results and protecting owner privacy.
+description: >-
+  A revoked product credential does not prove a fake. A resale guide to checking
+  current status, handling stale results and protecting owner privacy.
+tags:
+  - provenance
+  - authentication
+  - infrastructure
+  - luxury
 published: true
-coverImage: "/images/blog/product-passport-revocation-resale.jpg"
-coverImageAlt: "An intact black leather handbag beside a separate glass certificate with an interrupted amber ring and cyan edges"
+coverImage: /images/blog/product-passport-revocation-resale.jpg
+coverImageAlt: >-
+  An intact black leather handbag beside a separate glass certificate with an
+  interrupted amber ring and cyan edges
 faq:
-  - question: "Does a revoked product passport mean the item is counterfeit?"
-    answer: "No. Revocation concerns a particular credential and must be interpreted under its issuer's policy. It may reflect compromised signing material or replacement of a record. The product's authenticity, ownership and condition need separate evidence. Stop relying on the revoked credential and ask the issuer for clarification."
-  - question: "Can a reseller accept a cached passport status?"
-    answer: "Only within a defined verification policy that respects the credential's validity and the applicable status mechanism. A recent download does not make an old signed statement current. Record the statement's time and the check time, refresh when required, and hold a certificate-dependent decision if the evidence is too old or unavailable."
-  - question: "Does an unavailable status service mean a credential is revoked?"
-    answer: "No. A timeout, unsupported format or failed status retrieval means the check could not establish the status. It must not become either a counterfeit accusation or an automatic approval. Explain the missing check, retry through the documented service and offer an issuer or specialist review."
-  - question: "Can checking passport status expose a customer's activity?"
-    answer: "It can. Requests tied to one credential can reveal when and where it is presented. Shared status lists and controlled caching can reduce this exposure, but do not guarantee anonymity. Avoid attaching customer identity to public status requests and keep transaction records under access controls."
+  - question: Does a revoked product passport mean the item is counterfeit?
+    answer: >-
+      No. Revocation concerns a particular credential and must be interpreted
+      under its issuer's policy. It may reflect compromised signing material or
+      replacement of a record. The product's authenticity, ownership and
+      condition need separate evidence. Stop relying on the revoked credential
+      and ask the issuer for clarification.
+  - question: Can a reseller accept a cached passport status?
+    answer: >-
+      Only within a defined verification policy that respects the credential's
+      validity and the applicable status mechanism. A recent download does not
+      make an old signed statement current. Record the statement's time and the
+      check time, refresh when required, and hold a certificate-dependent
+      decision if the evidence is too old or unavailable.
+  - question: Does an unavailable status service mean a credential is revoked?
+    answer: >-
+      No. A timeout, unsupported format or failed status retrieval means the
+      check could not establish the status. It must not become either a
+      counterfeit accusation or an automatic approval. Explain the missing
+      check, retry through the documented service and offer an issuer or
+      specialist review.
+  - question: Can checking passport status expose a customer's activity?
+    answer: >-
+      It can. Requests tied to one credential can reveal when and where it is
+      presented. Shared status lists and controlled caching can reduce this
+      exposure, but do not guarantee anonymity. Avoid attaching customer
+      identity to public status requests and keep transaction records under
+      access controls.
 ---
 
 A revoked product credential does not, by itself, prove that the physical item is counterfeit. A reseller should stop relying on that credential, establish what changed and keep an unavailable or outdated status separate from an authenticity verdict.
 
 That distinction becomes practical at the resale counter. The seller has a bag, the phone displays a certificate, and the buyer wants a decision. A signature can still check out while the issuer has withdrawn the statement. A perfectly genuine object can also arrive with a damaged tag, a replaced credential or an inaccessible service.
 
-This is an operational guide for teams using digitally signed product records. It is not a claim that every Digital Product Passport uses W3C credentials, a new regulatory obligation, or a description of a deployed Galileo verification feature.
+This guide concerns digitally signed product records. Other passport formats may use different verification mechanisms.
 
 ## Start with the claim that the certificate actually makes
 
@@ -40,9 +70,7 @@ Write those distinctions into the intake form before choosing a colour for the s
 
 ## A revoked credential is not a counterfeit finding
 
-W3C explains in [Bitstring Status List v1.0, section 1.1](https://www.w3.org/TR/vc-bitstring-status-list/#conceptual-framework) that status information **“is about the verifiable credential itself and might not apply to any underlying or backing credential”**. This excerpt concerns the credential status, not the underlying object. The Recommendation is dated 15 May 2025.
-
-The note uses a degree as an example: compromised signing material can invalidate a digital credential while the underlying qualification remains valid. Applied to a product record, the same distinction prevents a technical withdrawal from becoming an unsupported accusation about a bag.
+[W3C Bitstring Status List v1.0, section 1.1](https://www.w3.org/TR/vc-bitstring-status-list/#conceptual-framework), a Recommendation dated 15 May 2025, distinguishes the status of a digital credential from the underlying qualification it describes. For a product record, withdrawal likewise needs to be interpreted separately from the physical item's authenticity.
 
 This application is our analysis. An issuer might withdraw a product credential after discovering an error, or replace it under a documented recovery process. Those are possible scenarios, not asserted explanations for a real revocation. The reseller needs the issuer's authenticated explanation and any replacement evidence before relying on either.
 
@@ -83,7 +111,7 @@ That separation also makes escalation useful. The issuer can explain its credent
 
 Caching means keeping a local copy to avoid fetching the same information repeatedly. It can improve speed and availability, but it changes what a verifier knows at the moment of sale.
 
-In its January 2026 [Digital Signatures Technical Implementation Guideline](https://ref.gs1.org/guidelines/digital-signatures/), GS1 describes caching a DigSig Certificate in constrained connectivity. Its qualification on printed page 35 is direct: **“Note that revocation checks should be done online.”** This guidance concerns that DigSig workflow; it should not be misrepresented as the operating rule of every credential format.
+In its January 2026 [Digital Signatures Technical Implementation Guideline](https://ref.gs1.org/guidelines/digital-signatures/), GS1 discusses keeping a local copy of a DigSig Certificate while checking revocation online. That guidance concerns the DigSig workflow; use the documented rules for the credential format your team actually receives.
 
 For a resale team, the practical implication is to distinguish locally verified material from a current status check. A screenshot taken yesterday may record a genuine result from yesterday. It says nothing reliable about changes since then.
 
@@ -131,7 +159,7 @@ Before relying on a provider's scan result, ask for a demonstration with deliber
 - Replace a credential through the issuer's documented process. Can the reviewer follow the relationship without losing the earlier record?
 - Inspect a status request. Is customer identity disclosed when the mechanism does not need it?
 
-These are procurement questions and recommended acceptance checks. They are not assertions about an existing provider's implementation, including Galileo's. The provider should show the relevant version, configuration and evidence rather than answer with a standards logo.
+Ask the provider to demonstrate the relevant version, configuration and results for these cases.
 
 This is the operational continuation of [portable proof in the secondary market](/blog/2026-08-30-fpjourne-secondary-market-portable-proof). A record needs to travel, but the next holder must also understand when it can be relied upon and how uncertainty is resolved.
 

--- a/website/content/blog/2026-09-05-product-passport-revocation-resale.mdx
+++ b/website/content/blog/2026-09-05-product-passport-revocation-resale.mdx
@@ -4,10 +4,10 @@ date: '2026-09-05'
 modified: '2026-09-12'
 author: Pierre Beunardeau
 excerpt: >-
-  A revoked product credential does not prove a fake. A resale guide to checking
+  A revoked product certificate does not prove a fake. A resale guide to checking
   current status, handling stale results and protecting owner privacy.
 description: >-
-  A revoked product credential does not prove a fake. A resale guide to checking
+  A revoked product certificate does not prove a fake. A resale guide to checking
   current status, handling stale results and protecting owner privacy.
 tags:
   - provenance
@@ -22,7 +22,7 @@ coverImageAlt: >-
 faq:
   - question: Does a revoked product passport mean the item is counterfeit?
     answer: >-
-      No. Revocation concerns a particular credential and must be interpreted
+      No. Revocation concerns a particular signed product statement and must be interpreted
       under its issuer's policy. It may reflect compromised signing material or
       replacement of a record. The product's authenticity, ownership and
       condition need separate evidence. Stop relying on the revoked credential
@@ -50,7 +50,7 @@ faq:
       access controls.
 ---
 
-A revoked product credential does not, by itself, prove that the physical item is counterfeit. A reseller should stop relying on that credential, establish what changed and keep an unavailable or outdated status separate from an authenticity verdict.
+A revoked product credential (a digitally signed statement about an item) does not, by itself, prove that the item is counterfeit. A reseller should stop relying on that statement, establish what changed and keep an unavailable or outdated status separate from an authenticity verdict.
 
 That distinction becomes practical at the resale counter. The seller has a bag, the phone displays a certificate, and the buyer wants a decision. A signature can still check out while the issuer has withdrawn the statement. A perfectly genuine object can also arrive with a damaged tag, a replaced credential or an inaccessible service.
 
@@ -167,7 +167,7 @@ This is the operational continuation of [portable proof in the secondary market]
 
 ### Does a revoked product passport mean the item is counterfeit?
 
-No. Revocation concerns a particular credential and must be interpreted under its issuer's policy. It may reflect compromised signing material or replacement of a record. The product's authenticity, ownership and condition need separate evidence. Stop relying on the revoked credential and ask the issuer for clarification.
+No. Revocation concerns a particular signed product statement and must be interpreted under its issuer's policy. It may reflect compromised signing material or replacement of a record. The product's authenticity, ownership and condition need separate evidence. Stop relying on the revoked credential and ask the issuer for clarification.
 
 ### Can a reseller accept a cached passport status?
 

--- a/website/content/blog/2026-09-06-tokenized-shares-ownership-register.mdx
+++ b/website/content/blog/2026-09-06-tokenized-shares-ownership-register.mdx
@@ -1,153 +1,93 @@
 ---
-title: "Tokenized Shares: Who Records Your Ownership Today?"
-date: "2026-09-06"
-author: "Pierre Beunardeau"
-excerpt: "A token in your wallet is a starting point. Follow the share, the ownership record and the responsible party through the SEC's proposed changes."
-description: "A token in your wallet is a starting point. Follow the share, the ownership record and the responsible party through the SEC's proposed changes."
-tags: [tokenization, rwa, blockchain, securities]
+title: 'Tokenized Shares: Who Records Your Ownership Today?'
+date: '2026-09-06'
+author: Pierre Beunardeau
+excerpt: >-
+  A token in your wallet is a starting point. Follow the share, the ownership
+  record and the responsible party through the SEC's proposed changes.
+description: >-
+  A token in your wallet is a starting point. Follow the share, the ownership
+  record and the responsible party through the SEC's proposed changes.
+tags:
+  - tokenization
+  - rwa
+  - blockchain
+  - securities
 published: true
-coverImage: "/images/blog/tokenized-shares-ownership-register-v1.jpg"
-coverImageAlt: "A hand aligns a transparent cyan token with a separate archive mechanism on an obsidian background."
+coverImage: /images/blog/tokenized-shares-ownership-register-v1.jpg
+coverImageAlt: >-
+  A hand aligns a transparent cyan token with a separate archive mechanism on an
+  obsidian background.
 faq:
-  - question: "Does a token in my wallet prove that I own the referenced share?"
-    answer: "Not by itself. Identify the instrument, its issuer and its terms, then follow the relevant ownership records. A token may represent a share, an indirect interest through an intermediary, or a different instrument linked to the share's price."
-  - question: "Has the SEC adopted the September 2026 transfer agent proposal?"
-    answer: "As of 6 September 2026, the SEC lists this document as a proposed rule. This article does not present its proposed changes or consultation questions as adopted requirements."
-  - question: "Must my name appear on the company's own shareholder register?"
-    answer: "It depends on how the holding is structured. A registered owner holds shares directly with the company. A beneficial owner holds through an intermediary, whose records are part of the ownership trail. Check which structure the product uses."
-  - question: "Does this proposal require investors to put their identity on a public blockchain?"
-    answer: "This article identifies no such requirement. Consultation question 83 asks about associating blockchain records with information stored elsewhere. It must not be rewritten as an adopted requirement to publish personal identity data."
+  - question: Does a token in my wallet prove that I own the referenced share?
+    answer: >-
+      Not by itself. Identify the instrument, issuer and terms, then follow the
+      relevant ownership records. A token may represent a share, an indirect
+      interest or a different instrument linked to the share's performance.
+  - question: Has the SEC adopted the September 2026 transfer-agent proposal?
+    answer: >-
+      As of 12 September 2026, the SEC docket still lists a proposed rule. Its
+      deadline for comments is 3 November 2026. Proposed changes and
+      consultation questions are not adopted requirements.
+  - question: Must my name appear on the company's own shareholder register?
+    answer: >-
+      That depends on the holding structure. A registered owner holds directly
+      with the company. A beneficial owner holds through an intermediary whose
+      records are part of the ownership trail.
+modified: '2026-09-12'
 ---
-To understand what a tokenized share gives you, identify the instrument you bought and follow the ownership records behind it. The SEC's transfer agent proposal, dated 1 September 2026, makes that recordkeeping question timely, but it is a proposal, not a newly adopted rule.
+To understand a tokenized share, identify the instrument you bought and follow the ownership records behind it. A transfer between wallets does not, on its own, explain the rights received or which organisation must resolve a discrepancy.
 
-The interesting part of tokenization is not only that an asset can move between digital wallets. It is whether the person receiving it can understand what changed, which rights they now hold and whom to contact if the records disagree. That is a useful question for buyers, product teams and anyone building a service around digital assets.
+The SEC's US transfer-agent proposal, dated 1 September 2026, makes that question timely. The [rulemaking docket](https://www.sec.gov/rules-regulations/2026/09/s7-2026-30), checked on **12 September**, still lists a proposal, with comments due by **3 November 2026**.
 
-This article follows the US proposal and related official investor guidance, checked on 6 September. It does not assess a particular investment or extend the US framework to other jurisdictions.
+## Start with the instrument rather than its icon
 
-## Start with what the token represents
+Imagine a fictional investor, Maya, comparing two products labelled tokenized shares. Both appear in a wallet and refer to the same fictional company. She needs the terms before concluding that they provide the same rights.
 
-Imagine a fictional investor, Maya, comparing two products described as tokenized shares. Both appear in a wallet. Both refer to the same fictional company. The screens look reassuringly similar, but Maya has not yet checked whether the products give her the same rights.
+[Investor.gov's explanation of tokenized securities](https://www.investor.gov/introduction-investing/investing-basics/investment-products/tokenized-securities) distinguishes issuer-sponsored, custodial and synthetic arrangements. A synthetic instrument can track another security's performance without giving its holder claims against that security's issuer.
 
-She starts with the instrument's terms, not its icon. Who issued it? What exactly does she acquire? What document explains her rights? These questions sound less exciting than an instant transfer, yet they determine what she can reasonably expect after the transaction.
+Maya therefore records the instrument's name, its issuer and the document explaining her entitlement. A familiar company logo is not a substitute for those details.
 
-[Investor.gov's explanation of tokenized securities](https://www.investor.gov/introduction-investing/investing-basics/investment-products/tokenized-securities) distinguishes issuer-sponsored, custodial and synthetic models. In plain language, a token may represent a security issued through the company, an indirect interest held through an intermediary, or an instrument linked to another security's performance. According to that guidance, a synthetic instrument does not give its holder claims against the issuer of the referenced security.
+## Understand the record behind the holding
 
-The practical lesson is to avoid treating a familiar stock name as a complete description of the product. Maya writes down the legal name of the instrument and its issuer before comparing anything else. If she cannot find them, she has a missing answer, not a completed ownership check.
+A transfer agent helps maintain securities ownership records. The [SEC's proposed Transfer Agent Rules](https://www.sec.gov/files/rules/proposed/2026/34-106246.pdf), in the section titled “Master Securityholder File”, discuss the authoritative ownership record and how linked systems could support it.
 
-That distinction also helps product teams write clearer interfaces. A label such as “share” should lead to an explanation of the actual instrument. The user should not need to reconstruct the arrangement from a logo, a ticker symbol and a blockchain transaction.
+Question 83 asks about associating information on a blockchain with information held elsewhere, so that a token transfer corresponds to a change in the ownership file. It is a consultation question, not a final instruction to publish investors' identities on a public network.
 
-## Why the SEC proposal matters this week
+A second distinction matters for Maya. According to [Investor.gov's explanation of registered and beneficial owners](https://www.investor.gov/what-registered-owner-what-beneficial-owner), a registered owner holds directly with the company, while a beneficial owner holds through a bank or broker.
 
-A transfer agent helps maintain securities ownership records. The [SEC's proposed Transfer Agent Rules](https://www.sec.gov/files/rules/proposed/2026/34-106246.pdf), dated 1 September, address how those records are maintained and controlled. The proposal discusses electronic records and linked systems. The question for the reader is which record establishes ownership and who is responsible for maintaining it.
-
-One short sentence captures the point:
-
-> “The master securityholder file is the authoritative record of who owns an issuer’s securities.”
->
-> SEC, proposed Transfer Agent Rules, 1 September 2026, printed page 84.
-
-Here, the master securityholder file means the official record recognized by the issuer. The quoted passage describes its role; it does not say every buyer must personally appear on that record in every holding structure.
-
-Question 83 (printed page 140) asks how blockchain records could link to information held elsewhere, so that a token transfer corresponds to an ownership-file change. It is a question to consultees, not a finalized requirement. The [SEC rulemaking page](https://www.sec.gov/rules-regulations/2026/09/s7-2026-30) is the place to follow the proposal's status.
-
-For a reader, this creates a useful distinction: a digital transfer and the recognition of a holding need to be understood together. For an operator, the question becomes practical. Can someone explain the relationship between the records, including what happens when they do not agree?
-
-## A wallet address and a person's holding are different questions
-
-A wallet address identifies a destination in a blockchain system. Maya still needs to understand how the product connects that address with her holding. The answer depends on the arrangement she chose; it cannot be inferred from the address alone.
-
-Official guidance makes a second distinction. A [registered owner holds shares directly with the company; a beneficial owner holds through an intermediary](https://www.investor.gov/what-registered-owner-what-beneficial-owner). In the latter case, the intermediary's records matter to the ownership trail. The absence of Maya's name from the company's own register is therefore not, by itself, evidence that her holding is invalid.
-
-The question to ask is more precise: “Which record shows my position, and how does it connect to the company or the intermediary responsible for it?” This leaves room for different valid structures without pretending they are interchangeable.
-
-<figure>
-<svg viewBox="0 0 720 390" role="img" aria-label="Three questions connect the instrument, its ownership records and the responsible party. The wallet display alone does not answer all three." xmlns="http://www.w3.org/2000/svg">
-  <rect width="720" height="390" rx="20" fill="#000810" />
-  <g fontFamily="Arial, sans-serif" textAnchor="middle">
-    <rect x="60" y="24" width="600" height="88" rx="12" fill="#08202C" stroke="#22D3EE" />
-    <text x="360" y="60" fontSize="23" fill="#FFFFFF">What did you buy?</text>
-    <text x="360" y="90" fontSize="19" fill="#BFEAF1">Instrument, issuer, terms</text>
-    <path d="M360 118 V137" stroke="#22D3EE" strokeWidth="3" />
-    <rect x="60" y="144" width="600" height="88" rx="12" fill="#08202C" stroke="#22D3EE" />
-    <text x="360" y="180" fontSize="23" fill="#FFFFFF">Which records show the holding?</text>
-    <text x="360" y="210" fontSize="19" fill="#BFEAF1">Direct or through an intermediary</text>
-    <path d="M360 238 V257" stroke="#22D3EE" strokeWidth="3" />
-    <rect x="60" y="264" width="600" height="88" rx="12" fill="#08202C" stroke="#22D3EE" />
-    <text x="360" y="300" fontSize="23" fill="#FFFFFF">Who can explain a discrepancy?</text>
-    <text x="360" y="330" fontSize="19" fill="#BFEAF1">Named party and contact route</text>
-    <text x="360" y="378" fontSize="16" fill="#BFEAF1">Editorial checklist, not a regulatory test</text>
-  </g>
-</svg>
-<figcaption>Start with the instrument, follow its records, then identify the person or entity responsible for answering a discrepancy.</figcaption>
-</figure>
+Maya's name need not appear directly in the company's register for every valid holding structure. She needs to establish which record shows her position and how it connects to the company or intermediary responsible for it.
 
 ## Work through one fictional transfer
 
-Return to Maya's fictional example. She has chosen a product whose documentation describes direct registration. This is an assumption for the worked case, not a description of an existing platform or a Galileo feature.
+Suppose Maya chooses an arrangement whose documents describe direct registration. Before transferring, she identifies the party responsible for the ownership record and the process for receiving the instrument into an eligible wallet.
 
-Before the transfer, Maya saves the instrument's terms and identifies the party responsible for the ownership record. She checks the process for receiving the asset into an eligible wallet. If the documentation leaves that process unclear, she asks for clarification before proceeding.
+Afterwards, the wallet displays the token. Maya compares the confirmation provided by the arrangement with the instrument, quantity and transaction she expected. The purpose is to connect the particular digital operation to the promised holding, not to infer ownership from a similar name.
 
-After the transfer, her wallet shows the token. She then checks the confirmation offered by the arrangement she selected. Does it refer to the same instrument? Does it identify the expected holding? Can she connect it to the relevant transaction without guessing from a similar name?
+If the records appear to disagree, she keeps the references and asks the responsible party to explain the difference. That discrepancy does not require an immediate fraud accusation, but it should not disappear merely because the blockchain transaction succeeded.
 
-Now imagine that the wallet display and the confirmation appear to disagree. Maya does not need to decide instantly that the product is fraudulent, nor should she ignore the discrepancy because the blockchain transaction completed. She has a narrower task: preserve the references and ask the responsible party to explain the difference.
+A useful query names the instrument, transaction and conflicting confirmation. It asks which record establishes the current position and what is needed to resolve the mismatch.
 
-A useful message would name the instrument, the transaction reference and the conflicting confirmation. It would ask which record establishes the current position and what further information is needed. That gives the recipient something concrete to investigate.
+## Keep enough context for the next reader
 
-For a product team, this is a good interface review exercise. Put the two conflicting records in front of someone who did not build the system. Can they find the contact route and explain the problem? If they cannot, the product may need clearer support information even when its transaction display is technically correct.
+Retain the terms, the holding structure, the transaction-linked confirmation and a working contact route. Those pieces let Maya or an adviser reconstruct the position without collecting an unexplained folder of screenshots.
 
-## A short record trail you can actually use
+For a product team, the same exercise is a practical design check. Can a customer find the instrument's actual rights and the organisation responsible for the record? Can they report a discrepancy without guessing which support team owns it?
 
-Our editorial recommendation is to keep a compact record trail for the arrangement being assessed. It is a reading aid, not a legal checklist or a substitute for the product's governing documents.
-
-| Keep this answer | Why it helps | What should prompt a question |
-| --- | --- | --- |
-| The instrument and its issuer | Identifies what the token represents | Only the referenced company's brand is shown |
-| The terms describing the rights | Separates a label from the actual entitlement | Rights are implied in marketing but hard to locate in the terms |
-| The direct or intermediary holding structure | Explains which records belong in the trail | Nobody can explain where your position is recorded |
-| A confirmation linked to the transaction | Makes the specific event traceable | References or quantities appear inconsistent |
-| The responsible party and contact route | Makes a discrepancy actionable | Support cannot identify who maintains the relevant record |
-
-The aim is not to collect the largest possible folder. It is to leave enough context that you, a colleague or an adviser can follow the position later. A screenshot without the instrument's terms may be easy to save but hard to interpret.
-
-Keep unresolved points visible. Writing “confirmation requested” is more useful than treating a missing answer as an implicit success. When the answer arrives, attach it to the original question so that the next reader can understand what was clarified.
-
-This approach has a broader application than shares. Our [analysis of tokenization across financial and physical assets](/blog/2026-08-31-rwa-tokenization-leaves-finance-luxury-physical-assets) explains why the underlying rights and evidence differ between products. The question about responsible records remains useful, but the legal answer must be established for each arrangement.
-
-## What blockchain does not decide for the reader
-
-A transaction record can be part of the evidence you inspect. It does not remove the need to understand the instrument, the holding structure or the route for resolving a problem. Likewise, a technically readable record does not mean you have interpreted its legal effect correctly.
-
-For this article, the relevant boundary is especially important around identity. The proposal's question about linking records held on and off the blockchain must not become a claim that investors are required to publish personal identity data on a public network. The text discussed above does not establish that claim.
-
-Nor does a US transfer agent proposal tell a European issuer which authorization it needs. Readers working across jurisdictions should keep the legal scope attached to each source. Our [MiCA article on keeping a clear regulatory record trail](/blog/2026-09-03-mica-bitpanda-marketing-paper-trail) addresses a different framework; it should not be used as a substitute for securities analysis.
-
-When designing a record that someone else will rely on, explain these distinctions before choosing the technology. A person should be able to follow what the record represents and what remains to be established. No product capability, transfer-agent status or regulatory approval is claimed for Galileo in this worked example.
-
-If you are designing a verifiable-record experience, [read the Galileo documentation](/docs) and compare its documented scope with your actual requirements. Start with the right the token represents and the evidence a future reader will need.
+This discussion follows the US proposal and official investor education. It does not classify a particular investment or extend US rules to another jurisdiction. Our [MiCA guide](/blog/2026-08-25-mica-transitional-period-rwa) concerns a separate EU framework.
 
 ## Frequently asked questions
 
 ### Does a token in my wallet prove that I own the referenced share?
 
-Not by itself. Identify the instrument, its issuer and its terms, then follow the relevant ownership records. A token may represent a share, an indirect interest through an intermediary, or a different instrument linked to the share's price.
+Not by itself. Identify the instrument, issuer and terms, then follow the relevant ownership records. A token may represent a share, an indirect interest or a different instrument linked to the share's performance.
 
-### Has the SEC adopted the September 2026 transfer agent proposal?
+### Has the SEC adopted the September 2026 transfer-agent proposal?
 
-As of 6 September 2026, the SEC lists this document as a proposed rule. This article does not present its proposed changes or consultation questions as adopted requirements.
+As of 12 September 2026, the SEC docket still lists a proposed rule. Its deadline for comments is 3 November 2026. Proposed changes and consultation questions are not adopted requirements.
 
 ### Must my name appear on the company's own shareholder register?
 
-It depends on how the holding is structured. A registered owner holds shares directly with the company. A beneficial owner holds through an intermediary, whose records are part of the ownership trail. Check which structure the product uses.
+That depends on the holding structure. A registered owner holds directly with the company. A beneficial owner holds through an intermediary whose records are part of the ownership trail.
 
-### Does this proposal require investors to put their identity on a public blockchain?
-
-This article identifies no such requirement. Consultation question 83 asks about associating blockchain records with information stored elsewhere. It must not be rewritten as an adopted requirement to publish personal identity data.
-
-## Sources and method
-
-- [SEC: proposed Transfer Agent Rules, release 34-106246](https://www.sec.gov/files/rules/proposed/2026/34-106246.pdf), dated 1 September 2026. Printed pages 84 and 140 discussed above.
-- [SEC: rulemaking docket S7-2026-30](https://www.sec.gov/rules-regulations/2026/09/s7-2026-30), consulted 6 September 2026.
-- [Investor.gov: Tokenized Securities](https://www.investor.gov/introduction-investing/investing-basics/investment-products/tokenized-securities), consulted 6 September 2026. Investor education from SEC staff, not an additional rule.
-- [Investor.gov: registered and beneficial owners](https://www.investor.gov/what-registered-owner-what-beneficial-owner), consulted 6 September 2026.
-
-Method: primary-source reading followed by an editorial record-tracing exercise. Maya and the transaction are fictional. No platform was tested and no investment or customer outcome is reported.
+For the technical context of records that another person must interpret, [read the Galileo documentation](/docs). Begin with the right represented and the evidence the next holder will need.

--- a/website/content/blog/2026-09-07-luxury-repairs-workshop.mdx
+++ b/website/content/blog/2026-09-07-luxury-repairs-workshop.mdx
@@ -1,40 +1,66 @@
 ---
-title: "Luxury Repairs: What Leaves the Workshop with the Item?"
-date: "2026-09-07"
-modified: "2026-09-07"
-author: "Pierre Beunardeau"
-excerpt: "Give the next owner a useful repair history: approved work, replaced parts, remaining defects and warranty terms, with a reusable workshop handoff form."
-description: "Give the next owner a useful repair history: approved work, replaced parts, remaining defects and warranty terms, with a reusable workshop handoff form."
-tags: [luxury, repairs, provenance, after-sales]
+title: 'Luxury Repairs: What Leaves the Workshop with the Item?'
+date: '2026-09-07'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  Give the next owner a useful repair history: approved work, replaced parts,
+  remaining defects and warranty terms, with a reusable workshop handoff form.
+description: >-
+  Give the next owner a useful repair history: approved work, replaced parts,
+  remaining defects and warranty terms, with a reusable workshop handoff form.
+tags:
+  - luxury
+  - repairs
+  - provenance
+  - after-sales
 published: true
-coverImage: "/images/blog/luxury-repairs-workshop-v1.jpg"
-coverImageAlt: "An unbranded navy leather bag on a workshop bench beside a removed strap, leather tools and a closed folder"
+coverImage: /images/blog/luxury-repairs-workshop-v1.jpg
+coverImageAlt: >-
+  An unbranded navy leather bag on a workshop bench beside a removed strap,
+  leather tools and a closed folder
 faq:
-  - question: "What should accompany a luxury item after repair?"
-    answer: "Our recommended handoff includes item identification, intake condition, approved work, actual interventions, replaced parts, return checks, unresolved issues and the applicable service warranty. Keep supporting documents available and separate customer contact details from the record shared with a later buyer."
-  - question: "Does a repair record prove authenticity or resale value?"
-    answer: "No. It records what a stated workshop says it did to an identified item. Authenticity, ownership, present condition and resale valuation require their own evidence. A replacement part should be described without implying that the whole item has been authenticated."
-  - question: "Does a repair restart the warranty on the whole product?"
-    answer: "Do not assume that it does. Check the provider, country, service and written terms for that job. Record covered work or components, dates, exclusions and the claims route. If terms are missing, request them instead of inventing coverage or a duration."
-  - question: "Does this form require a digital product passport?"
-    answer: "No. The proposed method can use a paper record or an exportable digital file. A passport may carry or reference the history, but the record still needs an identifiable author and supporting evidence. This article does not establish a legal requirement or a deployed Galileo repair service."
+  - question: What should accompany a luxury item after repair?
+    answer: >-
+      Our recommended handoff includes item identification, intake condition,
+      approved work, actual interventions, replaced parts, return checks,
+      unresolved issues and the applicable service warranty. Keep supporting
+      documents available and separate customer contact details from the record
+      shared with a later buyer.
+  - question: Does a repair record prove authenticity or resale value?
+    answer: >-
+      No. It records what a stated workshop says it did to an identified item.
+      Authenticity, ownership, present condition and resale valuation require
+      their own evidence. A replacement part should be described without
+      implying that the whole item has been authenticated.
+  - question: Does a repair restart the warranty on the whole product?
+    answer: >-
+      Do not assume that it does. Check the provider, country, service and
+      written terms for that job. Record covered work or components, dates,
+      exclusions and the claims route. If terms are missing, request them
+      instead of inventing coverage or a duration.
+  - question: Does this form require a digital product passport?
+    answer: >-
+      No. The proposed method can use a paper record or an exportable digital
+      file. A passport may carry or reference the history, but the record still
+      needs an identifiable author and supporting evidence.
 ---
 
 After a luxury repair, send the item back with a record of the approved work, actual interventions, replaced parts, remaining defects and applicable service warranty. Give the next owner enough evidence to understand the repair without presenting that record as proof of authenticity or future resale value.
 
 A collection receipt can show that an object left the workshop. It may still leave a buyer unable to tell whether the strap was replaced, the movement serviced or a cosmetic treatment declined. The useful handoff answers those questions while the workshop can still resolve them.
 
-The method below is our editorial recommendation for after-sales teams and resellers. It is not a regulatory checklist or a description of a deployed Galileo repair service. The filled example is fictional; the source examples describe their own providers and markets.
+The following method is a practical recommendation for after-sales teams and resellers. The worked example is fictional; the named providers describe their own services and markets.
 
 ## Separate the digital service from the physical work
 
-In its [16 November 2023 explanation of its digital product passport](https://auraconsortium.com/insight/unlocking-luxury-digital-product-passport-transforms-the-luxury-industry), Aura Blockchain Consortium lists **“e-warranty, insurance, repair assistance”** under maintenance uses. This is the supplier's description, not a new 2026 announcement or evidence that every participating brand offers every service.
+In its [16 November 2023 explanation of its digital product passport](https://auraconsortium.com/insight/unlocking-luxury-digital-product-passport-transforms-the-luxury-industry), Aura Blockchain Consortium describes electronic warranty and repair-assistance uses. These are the supplier's stated uses, not evidence that every participating brand offers every service.
 
 A digital product passport is a record linked to a product. It can help carry information, but someone still has to describe what happened in the workshop. A link labelled repair history is not enough if the underlying document only says service completed.
 
 The physical scope also varies. [Hermès' US maintenance and repair page](https://www.hermes.com/us/en/content/278343-maintenance-repair/) describes leather interventions such as zipper replacement and seam repair alongside separate watch services. That page supports those examples, not a promise that any requested intervention will be accepted or covered by warranty.
 
-[Audemars Piguet's GB service page](https://www.audemarspiguet.com/gb/en/services/all-services) offers a useful counterpoint: its water-resistance service carries **“a warranty limited to the replaced components”**. The same page distinguishes an archive extract from an authenticity certificate requiring examination of the watch.
+[Audemars Piguet's GB service page](https://www.audemarspiguet.com/gb/en/services/all-services) gives a concrete boundary: the warranty for its water-resistance service is limited to the replaced components. The page also distinguishes an archive extract from an authenticity certificate requiring examination of the watch.
 
 These are different kinds of evidence: a supplier describes digital uses, while maisons describe physical services and document boundaries. The AP and Hermès pages are undated and were checked on 7 September 2026. Keep the provider, country and specific service attached to any terms you reuse.
 
@@ -98,7 +124,7 @@ If the terms are missing, mark warranty documentation pending and ask the provid
 
 ## A filled repair record: fictional bag, fictional workshop
 
-**Everything in this example is invented for training**, including the workshop, identifiers, dates, evidence references and limited service promise. It describes no Hermès, AP, Aura or Galileo customer or deployment. The hero image is an illustration, not evidence of this job.
+**The workshop, item, dates, records and service promise below are fictional.** They show how to describe a limited repair and its unresolved warranty question.
 
 Consider a resale team receiving a navy leather shoulder bag after an independent workshop replaced its strap. Here is the accompanying record.
 
@@ -137,7 +163,7 @@ Keep three conclusions separate in the listing: the documented intervention, the
 
 A digital passport could carry the summary or a controlled link to the supporting documents. Decide first who can issue corrections, which evidence remains accessible and what the buyer receives. The underlying repair evidence matters more than the choice of storage format.
 
-Where digitally signed records are used, our [passport revocation guide](/blog/2026-09-05-product-passport-revocation-resale) addresses whether a particular statement remains usable. That is a separate check from documenting the work performed. Nothing here establishes that Galileo currently delivers this proposed workshop workflow.
+Where digitally signed records are used, our [passport revocation guide](/blog/2026-09-05-product-passport-revocation-resale) explains how to check whether a particular statement remains usable.
 
 ## Frequently asked questions
 
@@ -155,6 +181,6 @@ Do not assume that it does. Check the provider, country, service and written ter
 
 ### Does this form require a digital product passport?
 
-No. The proposed method can use a paper record or an exportable digital file. A passport may carry or reference the history, but the record still needs an identifiable author and supporting evidence. This article does not establish a legal requirement or a deployed Galileo repair service.
+No. The proposed method can use a paper record or an exportable digital file. A passport may carry or reference the history, but the record still needs an identifiable author and supporting evidence.
 
 For the protocol context behind product records, [read the Galileo documentation](/docs). Use the form above to define the information your workshop and next buyer need before choosing an implementation.

--- a/website/content/blog/2026-09-08-material-marker-or-chip-dpp-binding.mdx
+++ b/website/content/blog/2026-09-08-material-marker-or-chip-dpp-binding.mdx
@@ -1,36 +1,70 @@
 ---
-title: "Material Marker or NFC Chip? A Supplier Trial Plan"
-date: "2026-09-08"
-modified: "2026-09-08"
-author: "Pierre Beunardeau"
-excerpt: "Compare material markers and NFC chips with proposed supplier tests for copied reads, moved parts, material replacement and supplier exit."
-description: "Compare material markers and NFC chips with proposed supplier tests for copied reads, moved parts, material replacement and supplier exit."
-tags: [authentication, provenance, luxury, dpp]
+title: Material Marker or NFC Chip? A Supplier Trial Plan
+date: '2026-09-08'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  Compare material markers and NFC chips with proposed supplier tests for copied
+  reads, moved parts, material replacement and supplier exit.
+description: >-
+  Compare material markers and NFC chips with proposed supplier tests for copied
+  reads, moved parts, material replacement and supplier exit.
+tags:
+  - authentication
+  - provenance
+  - luxury
+  - dpp
 published: true
-coverImage: "/images/blog/material-marker-or-chip-dpp-binding-v1.jpg"
-coverImageAlt: "Conceptual comparison bench with leather samples, a separate NFC inlay and an unbranded reader under cyan light"
+coverImage: /images/blog/material-marker-or-chip-dpp-binding-v1.jpg
+coverImageAlt: >-
+  Conceptual comparison bench with leather samples, a separate NFC inlay and an
+  unbranded reader under cyan light
 faq:
-  - question: "Should a luxury brand choose a material marker or an NFC chip?"
-    answer: "Choose against an agreed supplier trial for the product and decision you need. Compare copied readings, moved components, material replacement and supplier exit. Accept only the scope supported by recorded observations; an incomplete trial does not establish a winner."
-  - question: "Has SMX proved that its markers authenticate every luxury product?"
-    answer: "No such independent result is established here. SMX's 31 August 2026 company update claims invisible markers in luxury materials and continuity through their lifecycle. Those supplier claims need product-specific evidence before procurement relies on them."
-  - question: "Does a fresh NFC reading rule out a transplanted chip?"
-    answer: "No. Verifying a chip response does not establish that the chip remains on its original product. A fresh reading also does not exclude every real-time relay. Test the actual attachment and server rules separately."
-  - question: "What should the trial sheet record before supplier acceptance?"
-    answer: "Record the sample, unchanged control, authorised manipulation, configuration, evidence, observed result, limitation and conditional decision. Leave observations blank until the trial is performed. Require follow-up for missing results and distinguish historical record access from the ability to make a new reading."
+  - question: Should a luxury brand choose a material marker or an NFC chip?
+    answer: >-
+      Choose against an agreed supplier trial for the product and decision you
+      need. Compare copied readings, moved components, material replacement and
+      supplier exit. Accept only the scope supported by recorded observations;
+      an incomplete trial does not establish a winner.
+  - question: Has SMX proved that its markers authenticate every luxury product?
+    answer: >-
+      No such independent result is established here. SMX's 31 August 2026
+      company update claims invisible markers in luxury materials and continuity
+      through their lifecycle. Those supplier claims need product-specific
+      evidence before procurement relies on them.
+  - question: Does a fresh NFC reading rule out a transplanted chip?
+    answer: >-
+      No. Verifying a chip response does not establish that the chip remains on
+      its original product. A fresh reading also does not exclude every
+      real-time relay. Test the actual attachment and server rules separately.
+  - question: What should the trial sheet record before supplier acceptance?
+    answer: >-
+      Record the sample, unchanged control, authorised manipulation,
+      configuration, evidence, observed result, limitation and conditional
+      decision. Leave observations blank until the trial is performed. Require
+      follow-up for missing results and distinguish historical record access
+      from the ability to make a new reading.
 ---
 
 Choose a material marker or an NFC chip only after a supplier trial tests copied readings, moved components, material replacement and supplier exit. Accept the specific product and verification process supported by the evidence, rather than treating a successful scan as approval of the whole system.
 
 For a luxury brand or resale operator, the practical question is whether staff can make the same defensible acceptance decision after something goes wrong. NFC means near-field communication, the short-range radio connection used to read a compatible chip. A material marker is a detectable addition to the material itself.
 
-The protocol below is an **editorial proposal, not a report of tests performed**. The cover is a conceptual illustration, not an SMX instrument, a visible molecular marker or evidence of a successful trial.
+The trials below are proposed procurement checks, not reported test results. The cover is a conceptual illustration.
+
+## A fictional decision before a resale pilot
+
+**Consider a fictional resale team comparing two proposals.** It needs to verify a bag's body after a strap replacement. One proposal marks the strap; the other mounts a chip in the body.
+
+At the planning stage, the lead puts the strap-only proposal on hold for this use case: checking the replaced strap would not answer the agreed question about the body. The lead requests a body-specific marker proposal and the transplant trial for the chip mounting. Neither candidate has passed; both still need observations in the sheet.
+
+The example sets the scope of a possible pilot. Neither technology has passed a trial, and the choice cannot be settled until the relevant observations exist.
 
 ## What the supplier documents actually establish
 
 In its [31 August 2026 company update](https://newsroom.smx.tech/articles/1214617/luxury-has-an-authentication-problem-smx-is-putting-the-proof-inside-the-product), SMX says it embeds invisible molecular markers in materials including textiles, leather and precious metals. SMX presents this approach as a way to connect material to a digital record through its lifecycle. These are supplier claims; no independent comparative performance result is established here.
 
-Treat that announcement as an invitation to request evidence for your material, finish and intended intervention. It does not establish universal resistance, reading accuracy or suitability for every finished product. The announcement dates from August, not a new September launch.
+Request evidence for your material, finish and intended intervention before relying on the supplier's claim.
 
 A chip offers a different testable mechanism. [NXP's NTAG 424 DNA TT datasheet](https://www.nxp.com/docs/en/data-sheet/NT4H2421Tx.pdf), Rev. 3.0 of 31 January 2019, describes Secure Dynamic Messaging, or SDM, a protected read message. Section 9.3 explains how a read counter and verifying-server rules can limit replay, the reuse of an earlier valid reading. This is one chip and configuration, not a property of all NFC tags.
 
@@ -134,14 +168,6 @@ Use one copy per candidate, sample and manipulation. Complete the plan before te
 - **Decision owner, date and required retest:** ____________________
 
 Keep sensitive keys and personal information out of the shareable evidence pack. Retain enough configuration detail for an authorised reviewer to reproduce the decision. The sheet is a procurement aid, not a certification or a substitute for specialist testing.
-
-## A fictional decision before a resale pilot
-
-**This example is fictional, including the brand, samples and decision. No vendor performance or trial outcome is asserted.** A resale team plans to accept bags only if staff can verify the body after a strap replacement. Its procurement lead compares a proposed marked strap with a proposed chip mounted in the body.
-
-At the planning stage, the lead puts the strap-only proposal on hold for this use case: checking the replaced strap would not answer the agreed question about the body. The lead requests a body-specific marker proposal and the transplant trial for the chip mounting. Neither candidate has passed; both still need observations in the sheet.
-
-This is a decision about scope before spending on a pilot. It does not infer that a marker is weaker, that the chip is secure or that either supplier failed an actual test. Nothing in this proposed workflow establishes a Galileo deployment or integration with these suppliers.
 
 ## Frequently asked questions
 

--- a/website/content/blog/2026-09-09-visual-authentication-dead-superclones-provenance.mdx
+++ b/website/content/blog/2026-09-09-visual-authentication-dead-superclones-provenance.mdx
@@ -1,103 +1,92 @@
 ---
-title: "Why Visual Authentication Fails Against Super-Clones"
-date: "2026-09-09"
-modified: "2026-09-09"
-author: "Pierre Beunardeau"
-excerpt: "High-end counterfeits match factory tolerances. Why visual appraisal fails and how verifiable digital product passports provide tamper-evident provenance."
-description: "High-end counterfeits match factory tolerances. Why visual appraisal fails and how verifiable digital product passports provide tamper-evident provenance."
-tags: [counterfeiting, provenance, luxury, dpp, watches]
+title: 'Super-Clones: Why Authentication Needs Several Checks'
+date: '2026-09-09'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  Counterfeit-watch seizures show a real risk, not the end of visual expertise.
+  Combine physical examination, provenance and checks on digital records.
+description: >-
+  Counterfeit-watch seizures show a real risk, not the end of visual expertise.
+  Combine physical examination, provenance and checks on digital records.
+tags:
+  - counterfeiting
+  - provenance
+  - luxury
+  - dpp
+  - watches
 published: true
-coverImage: "/images/blog/visual-authentication-dead-superclones-provenance.jpg"
-coverImageAlt: "A mechanical watch movement overlayed with cyan digital circuit lines and data particles"
+coverImage: /images/blog/visual-authentication-dead-superclones-provenance.jpg
+coverImageAlt: >-
+  A mechanical watch movement overlayed with cyan digital circuit lines and data
+  particles
 faq:
-  - question: "Why has visual expertise become unreliable for modern luxury goods?"
-    answer: "Advanced counterfeit operations now utilize five-axis CNC milling, optical laser etching and genuine materials. When physical tolerances match factory specifications within microns, human visual inspection cannot reliably establish authenticity."
-  - question: "Can artificial intelligence image recognition solve the super-clone problem?"
-    answer: "No. Computer vision algorithms evaluate visible surface textures and stitching geometry. If a counterfeit reproduces those surface features accurately, optical AI simply confirms the visual plausibility of the fake."
-  - question: "What is the difference between inspecting an object and verifying provenance?"
-    answer: "Object inspection asks whether an item looks genuine at a single point in time. Provenance verification examines the unbroken, cryptographically signed chain of custody from the original manufacture to the current owner."
-  - question: "How does a Digital Product Passport improve counterfeit resilience?"
-    answer: "A digital passport relies on asymmetric cryptography and physical anchors. While physical forms can be imitated, counterfeiters cannot forge the private cryptographic signature of the issuing maison."
-  - question: "What role does the EU ESPR framework play in digital product identity?"
-    answer: "The Ecodesign for Sustainable Products Regulation establishes the European framework for Digital Product Passports, introducing standardized digital identities phased in through product-specific delegated acts."
+  - question: Do sophisticated counterfeits make physical examination useless?
+    answer: >-
+      No such conclusion follows from the sources discussed here. Examination
+      can reveal evidence about construction and condition. Its limits should be
+      assessed for the method and object concerned, alongside provenance and
+      seller evidence.
+  - question: Does a valid digital signature prove that the physical item is genuine?
+    answer: >-
+      No. It can support verification of a signed statement and its issuer under
+      the system's rules. It does not by itself establish the truth of the
+      claim, the item's present condition or the absence of substitution.
+  - question: Does revocation mean a product has been stolen or counterfeited?
+    answer: >-
+      Not by itself. A credential-status mechanism records the status of an
+      attestation. The reason and its consequences depend on the issuer's policy
+      and supporting evidence; theft and counterfeit findings need their own
+      basis.
 ---
+A buyer facing a possible “super-clone” needs physical examination, a documented history and checks on any digital evidence. The sources discussed here do not establish that visual expertise has become useless or that cryptography can replace it.
 
-Visual authentication can no longer protect the secondary luxury market. High-grade counterfeit workshops replicate case geometry, weight and engraving within microscopic manufacturing tolerances. Trusting human visual inspection alone leaves significant residual risk. Moving from subjective appraisal to verifiable evidence requires unbroken cryptographic provenance anchored to the physical object.
+“Super-clone” is used here for a counterfeit presented as a close imitation. It is not a measured accuracy class. Claims that such objects universally match factory tolerances or defeat every examiner would require evidence from a defined evaluation.
 
-For decades, the luxury industry treated authentication as an artisanal craft. Experienced watchmakers inspected date wheels, font serif weights and leather grain to declare an item authentic. Today, that paradigm has collapsed under the weight of industrial-scale super-clones, as reflected in repeated multi-million-dollar counterfeit watch seizures by [U.S. Customs and Border Protection](https://www.cbp.gov/newsroom/local-media-release/cbp-louisville-seizes-counterfeit-watches-worth-over-10m).
+## What the seizures establish
 
-## The mechanical convergence of super-clones
+[US Customs and Border Protection's 26 August 2026 release](https://www.cbp.gov/newsroom/national-media-release/louisville-cbp-intercepts-9-million-shipment-counterfeit-watches) describes counterfeit watches and shoes intercepted in Louisville. It also recommends looking for warning signs in the goods and their presentation.
 
-The counterfeit ecosystem has evolved from crude street replicas to sophisticated parallel manufacturing. Illicit workshops operate five-axis CNC machines, laser sintering printers and spectrometer-calibrated ceramic kilns.
+That source demonstrates an interception. It does not measure microscopic manufacturing accuracy, the failure rate of specialists or the performance of an automated image system. The [four-shipment analysis](/blog/2026-08-27-cbp-louisville-fake-watches-border-enforcement) keeps those enforcement figures separate from wider authentication claims.
 
-This technical convergence creates three blind spots for traditional inspection:
+Physical examination remains one source of evidence. For example, [Audemars Piguet's official service page](https://www.audemarspiguet.com/gb/en/services/all-services) distinguishes an archive extract from an authenticity certificate requiring examination of the watch.
 
-1. **Sub-micron dimensional accuracy**: case dimensions, bezel teeth and sapphire crystal curvatures now match factory specifications within tolerances undetectable by handheld loupes.
-2. **Cloned mechanical calibres**: movement counterfeiters no longer disguise cheap quartz movements beneath solid casebacks. They replicate bridges, balance wheels and escapement architectures, creating movements that wind and beat identically to authentic calibres.
-3. **Genuine component blending**: illicit assemblers mix authentic parts acquired through gray-market servicing with counterfeit cases, rendering isolated spot-checks completely misleading.
+## A copied certificate can accompany a different object
 
-When an object looks and feels identical to the genuine article, evaluating the physical artifact in isolation ceases to be a reliable security test.
+Consider a fictional resale purchase. The seller provides a watch, a matching serial number and a screenshot of a digital certificate. A specialist finds no obvious discrepancy during an initial inspection.
 
-## Why computer vision algorithms repeat human errors
+The buyer still needs to establish whether the certificate was issued by the claimed source, what it covers and whether it describes this watch. A copied number or screenshot could refer to another object. A successful first inspection does not make those documentary questions unnecessary.
 
-Many resale platforms have turned to artificial intelligence and high-resolution camera rigs, hoping machine learning can spot microscopic discrepancies human eyes overlook.
+The reverse is also true. A valid document cannot reveal every later repair, replacement or change in physical condition. The buyer should ask the examiner and the issuer to answer the questions within their respective scope.
 
-While automated scanning increases operational throughput, it suffers from the same foundational limitation as manual appraisal:
+## What cryptography adds
 
-- **Optical bias**: computer vision models classify pixels based on training images of authentic products. When a super-clone replicates surface features accurately, the algorithm assigns a high probability score and validates the fake.
-- **Vulnerability to material drift**: natural materials such as exotic leathers or hand-finished watch components exhibit inherent variations. An optical system cannot determine whether a micro-variation represents artisanal tolerance or sophisticated fraud.
-- **Zero custody visibility**: a camera cannot determine where an item came from, who owned it, or whether its serial number was harvested from an authentic warranty card and engraved onto replicas.
+A digital signature helps check a signed statement under the chosen verification rules. The [W3C Verifiable Credentials Data Model 2.0](https://www.w3.org/TR/vc-data-model-2.0/), a Recommendation dated 15 May 2025, distinguishes verification from accepting the truth of the underlying claims.
 
-Authenticity cannot be inferred from appearance alone; it must be proven through origin.
+In the fictional sale, that means checking the issuer and record is useful, but it does not prove that no one moved the tag to another watch. The association between record and object needs its own evidence.
 
-<figure>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 270" role="img" aria-label="1. Physical tamper-resistant anchor, 2. Maison cryptographic signature, 3. Unbroken custody lifecycle">
-<rect width="600" height="270" rx="18" fill="#0B132B" />
-<rect x="24" y="20" width="552" height="64" rx="10" fill="#1C2541" stroke="#48CAE4" />
-<text x="46" y="60" fill="white" fontFamily="Arial,sans-serif" fontSize="22">1. Physical tamper-resistant anchor</text>
-<rect x="24" y="102" width="552" height="64" rx="10" fill="#1C2541" stroke="#48CAE4" />
-<text x="46" y="142" fill="white" fontFamily="Arial,sans-serif" fontSize="22">2. Maison cryptographic signature</text>
-<rect x="24" y="184" width="552" height="64" rx="10" fill="#1C2541" stroke="#48CAE4" />
-<text x="46" y="224" fill="white" fontFamily="Arial,sans-serif" fontSize="22">3. Unbroken custody &amp; servicing lifecycle</text>
-</svg>
-</figure>
+A material marker, an NFC chip and a digital signature also do different jobs. A marker may help identify material; a chip may communicate data or support a particular security mechanism. Neither term establishes what a supplier's exact product can detect. Our [material-marker and NFC comparison](/blog/2026-09-08-material-marker-or-chip-dpp-binding) proposes tests for copied readings, moved parts and replacements.
 
-## The three pillars of cryptographic provenance
+## Check the current statement, then explain the decision
 
-To establish verifiable provenance, luxury brands must separate the physical item from its digital identity while binding them with tamper-resistant protocols. Under the [W3C Verifiable Credentials Data Model 2.0](https://www.w3.org/TR/vc-data-model-2.0/), verifiability guarantees mathematical authorship and data integrity, while physical anchors bind the credential to the genuine good.
+An issuer may withdraw or replace a digital attestation. [W3C Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/), also dated 15 May 2025, supplies a mechanism for credential status. It is not, on its own, a complete register of stolen goods, ownership or repairs.
 
-| Security Layer | Traditional Physical Expertise | Cryptographic Digital Identity |
-| :--- | :--- | :--- |
-| Verification Vector | Subjective human visual inspection | Asymmetric cryptographic signature validation |
-| Replication Cost | Marginal cost for precision machine shops | Computationally infeasible without private keys |
-| Historical Context | Isolated snapshot without servicing context | Auditable chain of ownership, repairs and transfers |
-| Counterfeiter Countermeasure | Continual refinement of finishing and fonts | Target physical extraction or key compromise rather than replicating signatures |
+If the status cannot be established, describe the missing check. If the credential is revoked, stop relying on that statement and obtain the issuer's explanation. Neither event alone proves that the physical object is counterfeit.
 
-The architecture requires three synchronized elements:
-
-1. **A secure physical-digital link**: an embedded cryptographic tag, such as an encrypted NFC chip or molecular marker, evaluated in our comparative analysis of [markers versus NFC chips](/blog/2026-09-08-marker-vs-nfc-luxury-authentication).
-2. **An issuer-signed digital credential**: a Digital Product Passport structured under European standards like [Regulation (EU) 2024/1781 (ESPR)](https://eur-lex.europa.eu/eli/reg/2024/1781/oj/eng), recording serial numbers and certified technical specifications.
-3. **A verifiable status mechanism**: an open verification registry, such as the [W3C Bitstring Status List v1.0](https://www.w3.org/TR/vc-bitstring-status-list/), that tracks revocations, theft reports and servicing events across secondary market operators, as detailed in our guide on [product passport revocation](/blog/2026-09-05-product-passport-revocation-resale).
-
-## Galileo's take: from subjective opinion to verifiable math
-
-The future of luxury preservation cannot depend on an authenticator having a good day under a loupe. It must rest on cryptographic mathematics and verifiable custody.
-
-By providing the open protocol infrastructure for digital product passports, [Galileo's specifications](/specifications/identity) enable luxury maisons, certified repairers and resale platforms to verify origin independently. When provenance is embedded into the product's identity from manufacture, super-clones lose their primary advantage.
+For the fictional buyer, a usable decision combines the specialist's findings, the seller's evidence and the checked record. Each should say what it establishes and what remains unresolved.
 
 ## Frequently asked questions
 
-### Why has visual expertise become unreliable for modern luxury goods?
-Advanced counterfeit operations now utilize five-axis CNC milling, optical laser etching and genuine materials. When physical tolerances match factory specifications within microns, human visual inspection cannot reliably establish authenticity.
+### Do sophisticated counterfeits make physical examination useless?
 
-### Can artificial intelligence image recognition solve the super-clone problem?
-No. Computer vision algorithms evaluate visible surface textures and stitching geometry. If a counterfeit reproduces those surface features accurately, optical AI simply confirms the visual plausibility of the fake.
+No such conclusion follows from the sources discussed here. Examination can reveal evidence about construction and condition. Its limits should be assessed for the method and object concerned, alongside provenance and seller evidence.
 
-### What is the difference between inspecting an object and verifying provenance?
-Object inspection asks whether an item looks genuine at a single point in time. Provenance verification examines the unbroken, cryptographically signed chain of custody from the original manufacture to the current owner.
+### Does a valid digital signature prove that the physical item is genuine?
 
-### How does a Digital Product Passport improve counterfeit resilience?
-A digital passport relies on asymmetric cryptography and physical anchors. While physical forms can be imitated, counterfeiters cannot forge the private cryptographic signature of the issuing maison.
+No. It can support verification of a signed statement and its issuer under the system's rules. It does not by itself establish the truth of the claim, the item's present condition or the absence of substitution.
 
-### What role does the EU ESPR framework play in digital product identity?
-The Ecodesign for Sustainable Products Regulation establishes the European framework for Digital Product Passports, introducing standardized digital identities phased in through product-specific delegated acts.
+### Does revocation mean a product has been stolen or counterfeited?
+
+Not by itself. A credential-status mechanism records the status of an attestation. The reason and its consequences depend on the issuer's policy and supporting evidence; theft and counterfeit findings need their own basis.
+
+The [Galileo documentation](/docs) explains how product records can support that process. Evaluate the physical and documentary checks together before relying on an authenticity claim.

--- a/website/content/blog/2026-09-11-dpp-provider-exit.mdx
+++ b/website/content/blog/2026-09-11-dpp-provider-exit.mdx
@@ -1,35 +1,69 @@
 ---
-title: "DPP Provider Exit: Keep Product Passports Accessible"
-date: "2026-09-11"
-modified: "2026-09-11"
-author: "Pierre Beunardeau"
-excerpt: "Before choosing a digital product passport provider, test how records, printed links and access rights would survive a change of supplier."
-description: "Before choosing a digital product passport provider, test how records, printed links and access rights would survive a change of supplier."
-tags: [dpp, espr, infrastructure, interoperability]
+title: 'DPP Provider Exit: Keep Product Passports Accessible'
+date: '2026-09-11'
+modified: '2026-09-12'
+author: Pierre Beunardeau
+excerpt: >-
+  Before choosing a digital product passport provider, test how records, printed
+  links and access rights would survive a change of supplier.
+description: >-
+  Before choosing a digital product passport provider, test how records, printed
+  links and access rights would survive a change of supplier.
+tags:
+  - dpp
+  - espr
+  - infrastructure
+  - interoperability
 published: true
-coverImage: "/images/blog/dpp-provider-exit-v1.jpg"
-coverImageAlt: "A black leather handbag with a blank identity tag sits between two transparent archive cubes connected by cyan light."
+coverImage: /images/blog/dpp-provider-exit-v1.jpg
+coverImageAlt: >-
+  A black leather handbag with a blank identity tag sits between two transparent
+  archive cubes connected by cyan light.
 faq:
-  - question: "Will our passports keep working if the provider closes?"
-    answer: "That depends on your recoverable records, control of existing links, access permissions and replacement arrangements. Ask for a demonstrated handover before relying on a continuity promise. A contract or export file alone does not demonstrate that customers can still reach the right record."
-  - question: "Is a spreadsheet export enough to change providers?"
-    answer: "It may be one useful component. Check whether it preserves field definitions, units, attachments, record references, versions and the permissions needed for continued service. Then test an import elsewhere and scan an existing product label."
-  - question: "Can we keep the QR codes already printed on products?"
-    answer: "Possibly, if the existing address or identifier can still direct readers to the correct record under the replacement arrangement. Establish who controls that route and demonstrate it. If the failed supplier exclusively controls the printed address, a data export cannot by itself repair the link."
-  - question: "Does the European DPP registry back up every passport?"
-    answer: "Do not treat registration as your recovery copy. The Commission distinguishes registration information from the complete product information held by an economic operator or provider. Your continuity plan should identify where the usable passport copy is held and how an authorised replacement retrieves it."
-  - question: "What should we test before accepting an exit plan?"
-    answer: "Run an authorised trial that recovers representative records, imports them into the replacement and makes the original test service unavailable. Scan the existing labels, retrieve attachments, inspect corrections and check permitted and refused access. Record the tested scope and unresolved dependencies before deciding whether to accept the service."
+  - question: Will our passports keep working if the provider closes?
+    answer: >-
+      That depends on your recoverable records, control of existing links,
+      access permissions and replacement arrangements. Ask for a demonstrated
+      handover before relying on a continuity promise. A contract or export file
+      alone does not demonstrate that customers can still reach the right
+      record.
+  - question: Is a spreadsheet export enough to change providers?
+    answer: >-
+      It may be one useful component. Check whether it preserves field
+      definitions, units, attachments, record references, versions and the
+      permissions needed for continued service. Then test an import elsewhere
+      and scan an existing product label.
+  - question: Can we keep the QR codes already printed on products?
+    answer: >-
+      Possibly, if the existing address or identifier can still direct readers
+      to the correct record under the replacement arrangement. Establish who
+      controls that route and demonstrate it. If the failed supplier exclusively
+      controls the printed address, a data export cannot by itself repair the
+      link.
+  - question: Does the European DPP registry back up every passport?
+    answer: >-
+      Do not treat registration as your recovery copy. The Commission
+      distinguishes registration information from the complete product
+      information held by an economic operator or provider. Your continuity plan
+      should identify where the usable passport copy is held and how an
+      authorised replacement retrieves it.
+  - question: What should we test before accepting an exit plan?
+    answer: >-
+      Run an authorised trial that recovers representative records, imports them
+      into the replacement and makes the original test service unavailable. Scan
+      the existing labels, retrieve attachments, inspect corrections and check
+      permitted and refused access. Record the tested scope and unresolved
+      dependencies before deciding whether to accept the service.
 ---
 If your digital product passport (DPP) provider disappears, continued access depends on recoverable records, working product links and an authorised replacement. Before signing, ask the provider to demonstrate that handover using a label already attached to a product.
 
 This matters to the person scanning a bag in a resale store as much as to the team maintaining the records. An export sitting in a procurement folder is useful only if an authorised operator can turn it into an accessible, understandable passport.
 
-The EU framework supports interoperability and continuity. The practical question for a brand is how its chosen arrangement would deliver them. This guide separates that framework, checked on 11 September 2026, from an editorial method for evaluating a supplier and preparing an exit.
+The EU framework supports interoperability and continuity. This guide uses the rules checked on 12 September 2026 to explain what a brand should establish with its chosen provider.
 
 ## Start with the scan that must still work
 
-In a fictional example, a brand has printed passport labels for 500,000 products. Its provider announces that the service will close. The quantity and events are invented to illustrate the decision; they describe no existing brand or Galileo deployment.
+Consider a fictional brand with passport labels already attached to products. Its provider announces that the service will close, and the operations lead needs to keep the existing labels useful.
 
 The brand's operations lead receives a spreadsheet containing product identifiers and material descriptions. That is a promising start. She takes a sample product, scans its original label and reaches an address controlled by the outgoing supplier. Downloading the spreadsheet has not changed where that label sends the customer.
 
@@ -112,7 +146,7 @@ Have the contract reviewed for the actual legal arrangements, including insolven
 <figure>
 <svg viewBox="0 0 560 660" role="img" aria-labelledby="dpp-exit-title" aria-describedby="dpp-exit-description" xmlns="http://www.w3.org/2000/svg" className="mx-auto block h-auto w-full max-w-[560px]">
 <title id="dpp-exit-title">Four checks for a proposed provider exit</title>
-<desc id="dpp-exit-description">Keep the original product label connected to recoverable records, an authorised replacement and the information each reader may access. This is an editorial exercise, not a completed migration.</desc>
+<desc id="dpp-exit-description">Keep the original product label connected to recoverable records, an authorised replacement and the information each reader may access. A proposed handover, not a completed migration.</desc>
 <rect width="560" height="660" rx="20" fill="#000810" />
 <g fontFamily="inherit" textAnchor="middle">
 <g data-exit-step="label">
@@ -146,7 +180,7 @@ Have the contract reviewed for the actual legal arrangements, including insolven
 
 ## Rehearse the exit before accepting the service
 
-Use an isolated trial with authorised participants and representative test records. Agree the pass conditions in advance. The exercise below is a proposed method, not a report of a trial already performed.
+Run the proposed exercise in an isolated environment with authorised participants and representative test records. Agree the acceptance conditions before starting.
 
 **Choose a small but varied sample.** Include a current record, one with a correction, a restricted attachment and a reference to an older event. Add a deliberately unresolved case so that reviewers can see whether uncertainty survives the move. Choose the sample size to suit the decision; this guide sets no statistical acceptance threshold.
 
@@ -158,25 +192,15 @@ Use an isolated trial with authorised participants and representative test recor
 
 **Explain the result to someone who was not in the room.** Record what remained accessible, what failed, the conditions tested and the changes needed. A colleague should be able to follow the evidence without relying on the supplier's presentation. If a result depends on an untested emergency intervention, leave that dependency open.
 
-Return to the fictional brand with 500,000 labelled products. Suppose its trial recovers the public product descriptions, but workshop files remain inaccessible. The useful decision is to record public-record recovery as demonstrated within the trial and retain the workshop dependency as unresolved. It would be premature to announce a complete exit capability.
+Return to the fictional brand. Suppose the trial recovers public product descriptions, but workshop files remain inaccessible. Record public-record recovery as demonstrated within that trial and keep the workshop dependency open.
 
 The brand can then obtain the missing files or adjust the proposed service before expanding its reliance on it. If the remaining dependency is essential, it can defer acceptance until the next trial resolves it.
 
-## Put the results into the supplier agreement
+## Put the demonstrated handover into the agreement
 
-Ask procurement, operations and the technical owner to maintain one exit schedule attached to the agreement. Use the trial to make each entry concrete:
+Use the trial results to agree an exit schedule with the supplier. Name the records and attachments to deliver, the existing links to preserve, recovery access and the people responsible for the move. Include assistance, charges, restoration targets and dependencies on other parties.
 
-- **Records and files:** the data, documentation and attachments to be supplied, with formats, versions and permitted uses.
-- **Existing labels:** the addresses and identifiers to preserve, the party controlling each route, and the actions required for handover.
-- **Recovery access:** the location of the backup, the people allowed to retrieve it and the alternative route if the ordinary account fails. Assign any update to the provider reference recorded in the passport.
-- **Service continuity:** how the latest passport version reaches the backup, the target time for restoring access and each party's responsibilities during the transition.
-- **Permissions and evidence:** how reader roles, provenance, corrections and unresolved records are transferred and checked.
-- **Assistance and cost:** the migration tasks, named contacts, response commitments, charges and dependencies on other parties.
-- **Completion:** the acceptance evidence, treatment of retained copies and access removal after a verified handover, subject to applicable retention duties.
-
-Do not leave a critical field at *available on request*. Request the specimen, instruction or agreed commitment while the provider is able to answer. Keep any qualification beside the relevant promise so a future colleague can understand it.
-
-Repeat the exercise when a material dependency changes. A new hosting arrangement, identifier service or export format can change what the previous trial proved. The record should name the configuration that was actually tested.
+Define how the receiving team accepts the handover and how old access and retained copies are handled, subject to applicable retention duties. Obtain the instructions and specimen files while the provider can answer. Repeat the exercise when a material dependency changes; the earlier result covers the configuration actually tested.
 
 ## If the provider has already announced its departure
 

--- a/website/lighthouserc.json
+++ b/website/lighthouserc.json
@@ -40,6 +40,9 @@
         "http://localhost:3000/blog/2026-09-11-dpp-provider-exit"
       ],
       "numberOfRuns": 3,
+      "settings": {
+        "saveAssets": true
+      },
       "startServerCommand": "npm --prefix website run start -- --hostname 127.0.0.1",
       "startServerReadyPattern": "Ready in",
       "startServerReadyTimeout": 60000

--- a/website/src/components/layout/Navigation.tsx
+++ b/website/src/components/layout/Navigation.tsx
@@ -140,6 +140,7 @@ export function Navigation() {
 
       {/* Mobile Menu Overlay */}
       <div
+        inert={!isOpen}
         className={`fixed inset-0 z-40 md:hidden transition-all duration-500 ${
           isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
         }`}

--- a/website/src/components/layout/Navigation.tsx
+++ b/website/src/components/layout/Navigation.tsx
@@ -162,6 +162,7 @@ export function Navigation() {
               <Link
                 key={item.href}
                 href={item.href}
+                prefetch={isOpen ? null : false}
                 onClick={() => setIsOpen(false)}
                 className="py-4 text-2xl font-light text-white/80 hover:text-cyan-400 transition-colors border-b border-white/5"
                 style={{
@@ -178,6 +179,7 @@ export function Navigation() {
           <div className="mt-8">
             <Link
               href="/docs/quick-start"
+              prefetch={isOpen ? null : false}
               onClick={() => setIsOpen(false)}
               className="block w-full py-4 text-center bg-gradient-to-r from-cyan-500 to-emerald-500 text-black font-medium tracking-wide"
             >

--- a/website/src/lib/blog.ts
+++ b/website/src/lib/blog.ts
@@ -44,128 +44,6 @@ const TITLE_MAX = 60;
 // for OG crawlers and social cards.
 const COVER_IMAGE_MAX_BYTES = 150 * 1024;
 
-// Body sentences longer than 30 words are a style defect. The existing
-// corpus still has some, so this gate warns at build time instead of failing
-// the build (unlike the frontmatter validations above).
-const MAX_SENTENCE_WORDS = 30;
-
-// Placeholder used to protect dots that must not end a sentence
-// (abbreviations, decimal numbers) while splitting prose into sentences.
-const SENTENCE_DOT = '․';
-
-// Abbreviations whose trailing dot does not end a sentence.
-const ABBREVIATIONS = [
-  'art.',
-  'etc.',
-  'M.',
-  'Mme.',
-  'Mlle.',
-  'Dr.',
-  'Dr',
-  'fig.',
-  'vol.',
-  'p.ex.',
-  'e.g.',
-  'i.e.',
-  'cf.',
-  'vs.',
-  'No.',
-  'Mr.',
-  'Mrs.',
-  'U.S.',
-  'env.',
-];
-
-/**
- * Keep only body prose: drop fenced code blocks, headings, table rows, list
- * items and raw HTML/SVG lines (blank lines kept as paragraph breaks).
- */
-function extractProse(body: string): string {
-  const lines = body.split(/\r?\n/);
-  const kept: string[] = [];
-  let inFence = false;
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    if (trimmed === '') {
-      kept.push('');
-      continue;
-    }
-    if (/^([-*_]\s*){3,}$/.test(trimmed)) continue;
-    if (trimmed.startsWith('#')) continue;
-    if (trimmed.startsWith('|')) continue;
-    if (/^([-*+]|\d+[.)])\s/.test(trimmed)) continue;
-    if (trimmed.startsWith('<')) continue;
-    kept.push(trimmed);
-  }
-  return kept.join('\n');
-}
-
-/** Remove markdown inline markup, keeping only the visible words. */
-function stripInlineMarkup(text: string): string {
-  return text
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
-    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/`([^`]+)`/g, '$1')
-    .replace(/[*_~]/g, '')
-    .replace(/&[a-z]+;/gi, ' ');
-}
-
-/** Split prose into sentences on ". ! ?" followed by whitespace. */
-function splitSentences(prose: string): string[] {
-  let text = prose.replace(/\s+/g, ' ').trim();
-  if (text === '') return [];
-  text = text.replace(/(\d)\.(\d)/g, `$1${SENTENCE_DOT}$2`);
-  const sorted = [...ABBREVIATIONS].sort((a, b) => b.length - a.length);
-  for (const abbr of sorted) {
-    const escaped = abbr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    text = text.replace(new RegExp(escaped, 'g'), (m) =>
-      m.replace(/\./g, SENTENCE_DOT)
-    );
-  }
-  return text
-    .split(/(?<=[.!?]['"”’)\]*]*)\s+/)
-    .map((s) => s.replaceAll(SENTENCE_DOT, '.').trim())
-    .filter((s) => s !== '');
-}
-
-/** Count words in a sentence (tokens holding at least one letter/digit). */
-function countWords(sentence: string): number {
-  return stripInlineMarkup(sentence)
-    .split(/\s+/)
-    .filter((token) => /[\p{L}\p{N}]/u.test(token)).length;
-}
-
-/** Sentences in the article body longer than MAX_SENTENCE_WORDS words. */
-function findLongSentences(
-  body: string
-): { sentence: string; words: number }[] {
-  return splitSentences(extractProse(body))
-    .map((sentence) => ({ sentence, words: countWords(sentence) }))
-    .filter(({ words }) => words > MAX_SENTENCE_WORDS);
-}
-
-// getAllPosts() and getPostBySlug() both run during a build: warn once per file.
-const sentenceWarningsEmitted = new Set<string>();
-
-/** Warn (without failing the build) on over-long body sentences. */
-function warnOnLongSentences(filename: string, body: string): void {
-  if (sentenceWarningsEmitted.has(filename)) return;
-  sentenceWarningsEmitted.add(filename);
-  for (const { sentence, words } of findLongSentences(body)) {
-    const truncated =
-      sentence.length > 80 ? `${sentence.slice(0, 80)}…` : sentence;
-    console.warn(
-      `[blog] content/blog/${filename}: sentence is ${words} words (max ${MAX_SENTENCE_WORDS}): "${truncated}"`
-    );
-  }
-}
-
 function blogError(filename: string, message: string): never {
   throw new Error(
     `Invalid blog frontmatter in content/blog/${filename}: ${message}`
@@ -366,7 +244,6 @@ export function getAllPosts(): BlogPostMeta[] {
       const { data, content } = matter(fileContent);
 
       const frontmatter = normalizeFrontmatter(data, filename);
-      warnOnLongSentences(filename, content);
 
       return {
         slug,
@@ -414,7 +291,6 @@ export function getPostBySlug(slug: string): BlogPost | null {
   const { data, content } = matter(fileContent);
 
   const frontmatter = normalizeFrontmatter(data, path.basename(filePath));
-  warnOnLongSentences(path.basename(filePath), content);
 
   // Check if post is unpublished in production
   if (process.env.NODE_ENV === 'production' && !frontmatter.published) {


### PR DESCRIPTION
The 20 published blog articles now explain their subjects more directly, define unfamiliar terms, and distinguish verified facts from forecasts and historical claims. Sources, FAQ answers and modification dates are current as of 12 September 2026. Article URLs, original publication dates and cover images are preserved.

The closed mobile menu no longer prefetches hidden destinations or receives keyboard focus. The release audit recognizes verified GitHub squash merges only when the matching merged PR on this repository's main branch, signature, identity and parent checks agree. Lighthouse now retains its original navigation traces and network logs.

Validation on `bb8cc380d8c920675699a9da58f3214dab7500c2`:
- Independent article reviews passed; article bytes are unchanged since those reviews. The menu changes received two independent reviews. The trace-only change was reviewed separately.
- Website, apps and contracts CI passed. The full public-release audit passed, as did its 12 tests.
- The deployed preview served all 20 complete article bodies and their current metadata correctly, with 55 matching FAQ answers and 15 matching image files. Eight current desktop/mobile journeys passed, including keyboard navigation and the mobile CTA.

Lighthouse remains red: homepage performance was 80/97/97 on this candidate and 83/97/99 on the already-published base in a separate diagnostic run. All three runs on each of the other three routes passed. No result, threshold or run order was changed. This existing first-navigation defect is tracked separately in #39; its cause is not established. Article and functional checks pass.

Rollback: revert this PR and rebuild the preceding production revision `f74102ff235c6be31349171142d74b9fc1541a50`.

Fixes #35.

